### PR TITLE
[style] : add style guide - 11

### DIFF
--- a/TellingMe/Podfile
+++ b/TellingMe/Podfile
@@ -8,6 +8,7 @@ target 'tellingMe' do
   pod 'KakaoSDKCommon'
   pod 'KakaoSDKAuth'
   pod 'KakaoSDKUser'
+  pod 'Moya'
   # Pods for tellingMe
 
 end

--- a/TellingMe/Podfile.lock
+++ b/TellingMe/Podfile.lock
@@ -11,12 +11,17 @@ PODS:
     - KakaoSDKCommon/Common (= 2.14.0)
   - KakaoSDKUser (2.14.0):
     - KakaoSDKAuth (= 2.14.0)
+  - Moya (15.0.0):
+    - Moya/Core (= 15.0.0)
+  - Moya/Core (15.0.0):
+    - Alamofire (~> 5.0)
   - SwiftLint (0.49.1)
 
 DEPENDENCIES:
   - KakaoSDKAuth
   - KakaoSDKCommon
   - KakaoSDKUser
+  - Moya
   - SwiftLint
 
 SPEC REPOS:
@@ -25,6 +30,7 @@ SPEC REPOS:
     - KakaoSDKAuth
     - KakaoSDKCommon
     - KakaoSDKUser
+    - Moya
     - SwiftLint
 
 SPEC CHECKSUMS:
@@ -32,8 +38,9 @@ SPEC CHECKSUMS:
   KakaoSDKAuth: 8fca87815de22062a23297983f327613b087b8bb
   KakaoSDKCommon: 0ce638f7a2e49704943c0b74a087a9f8067bba1c
   KakaoSDKUser: 2ca18314ce72e6690f76cb1f6f9fbc771d31a803
+  Moya: 138f0573e53411fb3dc17016add0b748dfbd78ee
   SwiftLint: 32ee33ded0636d0905ef6911b2b67bbaeeedafa5
 
-PODFILE CHECKSUM: 61b898badfb7c1a9d8b920ff2577e382f0f9c4f4
+PODFILE CHECKSUM: 07e00945fa346bbc4f2b699e9a377dfa8c262bbc
 
 COCOAPODS: 1.11.3

--- a/TellingMe/tellingMe.xcodeproj/project.pbxproj
+++ b/TellingMe/tellingMe.xcodeproj/project.pbxproj
@@ -8,6 +8,14 @@
 
 /* Begin PBXBuildFile section */
 		3A2A503229B8806E002FE5E4 /* UIView+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A2A503129B8806E002FE5E4 /* UIView+.swift */; };
+		3A5076E129C82D4A00C7A5E9 /* NetworkLoggerPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A5076E029C82D4A00C7A5E9 /* NetworkLoggerPlugin.swift */; };
+		3A5076E329C82D7B00C7A5E9 /* Networkable+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A5076E229C82D7B00C7A5E9 /* Networkable+.swift */; };
+		3A5076E529C82D9800C7A5E9 /* ServiceError+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A5076E429C82D9800C7A5E9 /* ServiceError+.swift */; };
+		3A5076E729C82DB400C7A5E9 /* ResponseData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A5076E629C82DB400C7A5E9 /* ResponseData.swift */; };
+		3A5076E929C82DFE00C7A5E9 /* TargetType+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A5076E829C82DFE00C7A5E9 /* TargetType+.swift */; };
+		3A5076EB29C82E2F00C7A5E9 /* Encodable+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A5076EA29C82E2F00C7A5E9 /* Encodable+.swift */; };
+		3A5076F329C8335900C7A5E9 /* TestDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A5076F229C8335900C7A5E9 /* TestDTO.swift */; };
+		3A5076F529C8352200C7A5E9 /* TestDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A5076F429C8352200C7A5E9 /* TestDataSource.swift */; };
 		3A775CFC29C1AE8100FCD3BC /* NanumSquareRoundOTFR.otf in Resources */ = {isa = PBXBuildFile; fileRef = 3A775CF829C1AE8100FCD3BC /* NanumSquareRoundOTFR.otf */; };
 		3A775CFD29C1AE8100FCD3BC /* NanumSquareRoundOTFEB.otf in Resources */ = {isa = PBXBuildFile; fileRef = 3A775CF929C1AE8100FCD3BC /* NanumSquareRoundOTFEB.otf */; };
 		3A775CFE29C1AE8100FCD3BC /* NanumSquareRoundOTFL.otf in Resources */ = {isa = PBXBuildFile; fileRef = 3A775CFA29C1AE8100FCD3BC /* NanumSquareRoundOTFL.otf */; };
@@ -22,11 +30,22 @@
 		3AA289D729B8506F0030057E /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 3AA289D529B8506F0030057E /* LaunchScreen.storyboard */; };
 		3AA289E029B851DD0030057E /* .swiftlint.yml in Resources */ = {isa = PBXBuildFile; fileRef = 3AA289DF29B851DD0030057E /* .swiftlint.yml */; };
 		3AA289E229B854210030057E /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 3AA289E129B854210030057E /* Main.storyboard */; };
+		3AEED26329C99F1500D02F3F /* HeadlineLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AEED26229C99F1500D02F3F /* HeadlineLabel.swift */; };
+		3AEED26529C99F7D00D02F3F /* BodyLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AEED26429C99F7D00D02F3F /* BodyLabel.swift */; };
+		3AEED26729C99F8800D02F3F /* CaptionLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AEED26629C99F8800D02F3F /* CaptionLabel.swift */; };
 		878B59203EB71108991242CC /* Pods_tellingMe.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 66ED16CF904CB2601BAF24C5 /* Pods_tellingMe.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
 		3A2A503129B8806E002FE5E4 /* UIView+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+.swift"; sourceTree = "<group>"; };
+		3A5076E029C82D4A00C7A5E9 /* NetworkLoggerPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkLoggerPlugin.swift; sourceTree = "<group>"; };
+		3A5076E229C82D7B00C7A5E9 /* Networkable+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Networkable+.swift"; sourceTree = "<group>"; };
+		3A5076E429C82D9800C7A5E9 /* ServiceError+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ServiceError+.swift"; sourceTree = "<group>"; };
+		3A5076E629C82DB400C7A5E9 /* ResponseData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResponseData.swift; sourceTree = "<group>"; };
+		3A5076E829C82DFE00C7A5E9 /* TargetType+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TargetType+.swift"; sourceTree = "<group>"; };
+		3A5076EA29C82E2F00C7A5E9 /* Encodable+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Encodable+.swift"; sourceTree = "<group>"; };
+		3A5076F229C8335900C7A5E9 /* TestDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestDTO.swift; sourceTree = "<group>"; };
+		3A5076F429C8352200C7A5E9 /* TestDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestDataSource.swift; sourceTree = "<group>"; };
 		3A775CF829C1AE8100FCD3BC /* NanumSquareRoundOTFR.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = NanumSquareRoundOTFR.otf; sourceTree = "<group>"; };
 		3A775CF929C1AE8100FCD3BC /* NanumSquareRoundOTFEB.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = NanumSquareRoundOTFEB.otf; sourceTree = "<group>"; };
 		3A775CFA29C1AE8100FCD3BC /* NanumSquareRoundOTFL.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = NanumSquareRoundOTFL.otf; sourceTree = "<group>"; };
@@ -44,6 +63,9 @@
 		3AA289D829B8506F0030057E /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		3AA289DF29B851DD0030057E /* .swiftlint.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = .swiftlint.yml; sourceTree = "<group>"; };
 		3AA289E129B854210030057E /* Main.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = Main.storyboard; sourceTree = "<group>"; };
+		3AEED26229C99F1500D02F3F /* HeadlineLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeadlineLabel.swift; sourceTree = "<group>"; };
+		3AEED26429C99F7D00D02F3F /* BodyLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BodyLabel.swift; sourceTree = "<group>"; };
+		3AEED26629C99F8800D02F3F /* CaptionLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaptionLabel.swift; sourceTree = "<group>"; };
 		49060B55F5B6FD79F0C1DA8B /* Pods-tellingMe.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-tellingMe.release.xcconfig"; path = "Target Support Files/Pods-tellingMe/Pods-tellingMe.release.xcconfig"; sourceTree = "<group>"; };
 		66ED16CF904CB2601BAF24C5 /* Pods_tellingMe.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_tellingMe.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		9918CA7CFF0740644B11DD38 /* Pods-tellingMe.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-tellingMe.debug.xcconfig"; path = "Target Support Files/Pods-tellingMe/Pods-tellingMe.debug.xcconfig"; sourceTree = "<group>"; };
@@ -90,6 +112,8 @@
 		3A2A502F29B87C46002FE5E4 /* data */ = {
 			isa = PBXGroup;
 			children = (
+				3A5076EC29C82FE800C7A5E9 /* test */,
+				3A5076DF29C82D1C00C7A5E9 /* moya+ */,
 			);
 			path = data;
 			sourceTree = "<group>";
@@ -97,10 +121,49 @@
 		3A2A503029B8805F002FE5E4 /* util */ = {
 			isa = PBXGroup;
 			children = (
+				3AEED26129C99EDA00D02F3F /* custom */,
 				3A775D0629C1DBA900FCD3BC /* designable */,
 				3A775D0429C1D96800FCD3BC /* extension */,
 			);
 			path = util;
+			sourceTree = "<group>";
+		};
+		3A5076DF29C82D1C00C7A5E9 /* moya+ */ = {
+			isa = PBXGroup;
+			children = (
+				3A5076E029C82D4A00C7A5E9 /* NetworkLoggerPlugin.swift */,
+				3A5076E229C82D7B00C7A5E9 /* Networkable+.swift */,
+				3A5076E429C82D9800C7A5E9 /* ServiceError+.swift */,
+				3A5076E629C82DB400C7A5E9 /* ResponseData.swift */,
+				3A5076E829C82DFE00C7A5E9 /* TargetType+.swift */,
+				3A5076EA29C82E2F00C7A5E9 /* Encodable+.swift */,
+			);
+			path = "moya+";
+			sourceTree = "<group>";
+		};
+		3A5076EC29C82FE800C7A5E9 /* test */ = {
+			isa = PBXGroup;
+			children = (
+				3A5076F029C8334700C7A5E9 /* DataSource */,
+				3A5076EF29C8333700C7A5E9 /* DTO */,
+			);
+			path = test;
+			sourceTree = "<group>";
+		};
+		3A5076EF29C8333700C7A5E9 /* DTO */ = {
+			isa = PBXGroup;
+			children = (
+				3A5076F229C8335900C7A5E9 /* TestDTO.swift */,
+			);
+			path = DTO;
+			sourceTree = "<group>";
+		};
+		3A5076F029C8334700C7A5E9 /* DataSource */ = {
+			isa = PBXGroup;
+			children = (
+				3A5076F429C8352200C7A5E9 /* TestDataSource.swift */,
+			);
+			path = DataSource;
 			sourceTree = "<group>";
 		};
 		3A775D0429C1D96800FCD3BC /* extension */ = {
@@ -163,7 +226,6 @@
 			isa = PBXGroup;
 			children = (
 				3A775D0929C2E9AE00FCD3BC /* keyChain */,
-				3A775D0329C1C3B500FCD3BC /* tellingMe.entitlements */,
 				3A775D0529C1D97300FCD3BC /* font */,
 				3A2A503029B8805F002FE5E4 /* util */,
 				3A2A502F29B87C46002FE5E4 /* data */,
@@ -171,8 +233,19 @@
 				3A2A502D29B87B9D002FE5E4 /* appDelegate */,
 				3AA289D329B8506F0030057E /* Assets.xcassets */,
 				3AA289D529B8506F0030057E /* LaunchScreen.storyboard */,
+				3A775D0329C1C3B500FCD3BC /* tellingMe.entitlements */,
 			);
 			path = tellingMe;
+			sourceTree = "<group>";
+		};
+		3AEED26129C99EDA00D02F3F /* custom */ = {
+			isa = PBXGroup;
+			children = (
+				3AEED26229C99F1500D02F3F /* HeadlineLabel.swift */,
+				3AEED26429C99F7D00D02F3F /* BodyLabel.swift */,
+				3AEED26629C99F8800D02F3F /* CaptionLabel.swift */,
+			);
+			path = custom;
 			sourceTree = "<group>";
 		};
 		55FD0C4BC557B979A1A841D8 /* Pods */ = {
@@ -323,12 +396,23 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				3AEED26729C99F8800D02F3F /* CaptionLabel.swift in Sources */,
+				3A5076F329C8335900C7A5E9 /* TestDTO.swift in Sources */,
 				3A2A503229B8806E002FE5E4 /* UIView+.swift in Sources */,
 				3A775D0829C1DBBA00FCD3BC /* designable.swift in Sources */,
+				3A5076E729C82DB400C7A5E9 /* ResponseData.swift in Sources */,
+				3A5076EB29C82E2F00C7A5E9 /* Encodable+.swift in Sources */,
+				3A5076E529C82D9800C7A5E9 /* ServiceError+.swift in Sources */,
+				3A5076F529C8352200C7A5E9 /* TestDataSource.swift in Sources */,
+				3A5076E929C82DFE00C7A5E9 /* TargetType+.swift in Sources */,
+				3AEED26529C99F7D00D02F3F /* BodyLabel.swift in Sources */,
+				3A5076E329C82D7B00C7A5E9 /* Networkable+.swift in Sources */,
 				3AA289CF29B8506F0030057E /* ViewController.swift in Sources */,
 				3A775D0D29C2EA5400FCD3BC /* Bundle+.swift in Sources */,
+				3AEED26329C99F1500D02F3F /* HeadlineLabel.swift in Sources */,
 				3AA289CB29B8506F0030057E /* AppDelegate.swift in Sources */,
 				3AA289CD29B8506F0030057E /* SceneDelegate.swift in Sources */,
+				3A5076E129C82D4A00C7A5E9 /* NetworkLoggerPlugin.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/TellingMe/tellingMe/Assets.xcassets/colors/Contents.json
+++ b/TellingMe/tellingMe/Assets.xcassets/colors/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/TellingMe/tellingMe/Assets.xcassets/colors/Dark cyan.colorset/Contents.json
+++ b/TellingMe/tellingMe/Assets.xcassets/colors/Dark cyan.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.600",
+          "green" : "0.569",
+          "red" : "0.000"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "1.000",
+          "green" : "1.000",
+          "red" : "1.000"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/TellingMe/tellingMe/Assets.xcassets/colors/gradient/Contents.json
+++ b/TellingMe/tellingMe/Assets.xcassets/colors/gradient/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/TellingMe/tellingMe/Assets.xcassets/colors/gradient/gradient1.colorset/Contents.json
+++ b/TellingMe/tellingMe/Assets.xcassets/colors/gradient/gradient1.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.478",
+          "green" : "0.886",
+          "red" : "1.000"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "1.000",
+          "green" : "1.000",
+          "red" : "1.000"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/TellingMe/tellingMe/Assets.xcassets/colors/gradient/gradient2.colorset/Contents.json
+++ b/TellingMe/tellingMe/Assets.xcassets/colors/gradient/gradient2.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.894",
+          "green" : "1.000",
+          "red" : "0.941"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "1.000",
+          "green" : "1.000",
+          "red" : "1.000"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/TellingMe/tellingMe/Assets.xcassets/colors/gradient/gradient3.colorset/Contents.json
+++ b/TellingMe/tellingMe/Assets.xcassets/colors/gradient/gradient3.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "1.000",
+          "green" : "0.984",
+          "red" : "0.675"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "1.000",
+          "green" : "1.000",
+          "red" : "1.000"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/TellingMe/tellingMe/Assets.xcassets/colors/gray/Contents.json
+++ b/TellingMe/tellingMe/Assets.xcassets/colors/gray/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/TellingMe/tellingMe/Assets.xcassets/colors/gray/Gray0.colorset/Contents.json
+++ b/TellingMe/tellingMe/Assets.xcassets/colors/gray/Gray0.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "1.000",
+          "green" : "1.000",
+          "red" : "1.000"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "1.000",
+          "green" : "1.000",
+          "red" : "1.000"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/TellingMe/tellingMe/Assets.xcassets/colors/gray/Gray1.colorset/Contents.json
+++ b/TellingMe/tellingMe/Assets.xcassets/colors/gray/Gray1.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.945",
+          "green" : "0.945",
+          "red" : "0.933"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "1.000",
+          "green" : "1.000",
+          "red" : "1.000"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/TellingMe/tellingMe/Assets.xcassets/colors/gray/Gray2.colorset/Contents.json
+++ b/TellingMe/tellingMe/Assets.xcassets/colors/gray/Gray2.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.839",
+          "green" : "0.835",
+          "red" : "0.804"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "1.000",
+          "green" : "1.000",
+          "red" : "1.000"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/TellingMe/tellingMe/Assets.xcassets/colors/gray/Gray3.colorset/Contents.json
+++ b/TellingMe/tellingMe/Assets.xcassets/colors/gray/Gray3.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.729",
+          "green" : "0.722",
+          "red" : "0.671"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "1.000",
+          "green" : "1.000",
+          "red" : "1.000"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/TellingMe/tellingMe/Assets.xcassets/colors/gray/Gray4.colorset/Contents.json
+++ b/TellingMe/tellingMe/Assets.xcassets/colors/gray/Gray4.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.624",
+          "green" : "0.612",
+          "red" : "0.537"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "1.000",
+          "green" : "1.000",
+          "red" : "1.000"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/TellingMe/tellingMe/Assets.xcassets/colors/gray/Gray5.colorset/Contents.json
+++ b/TellingMe/tellingMe/Assets.xcassets/colors/gray/Gray5.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.439",
+          "green" : "0.431",
+          "red" : "0.361"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "1.000",
+          "green" : "1.000",
+          "red" : "1.000"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/TellingMe/tellingMe/Assets.xcassets/colors/gray/Gray6.colorset/Contents.json
+++ b/TellingMe/tellingMe/Assets.xcassets/colors/gray/Gray6.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.373",
+          "green" : "0.365",
+          "red" : "0.306"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "1.000",
+          "green" : "1.000",
+          "red" : "1.000"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/TellingMe/tellingMe/Assets.xcassets/colors/gray/Gray7.colorset/Contents.json
+++ b/TellingMe/tellingMe/Assets.xcassets/colors/gray/Gray7.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.243",
+          "green" : "0.235",
+          "red" : "0.196"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "1.000",
+          "green" : "1.000",
+          "red" : "1.000"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/TellingMe/tellingMe/Assets.xcassets/colors/gray/Gray8.colorset/Contents.json
+++ b/TellingMe/tellingMe/Assets.xcassets/colors/gray/Gray8.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.180",
+          "green" : "0.176",
+          "red" : "0.149"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "1.000",
+          "green" : "1.000",
+          "red" : "1.000"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/TellingMe/tellingMe/Assets.xcassets/colors/gray/black.colorset/Contents.json
+++ b/TellingMe/tellingMe/Assets.xcassets/colors/gray/black.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.149",
+          "green" : "0.149",
+          "red" : "0.122"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "1.000",
+          "green" : "1.000",
+          "red" : "1.000"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/TellingMe/tellingMe/Assets.xcassets/colors/main/Contents.json
+++ b/TellingMe/tellingMe/Assets.xcassets/colors/main/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/TellingMe/tellingMe/Assets.xcassets/colors/main/Primary100.colorset/Contents.json
+++ b/TellingMe/tellingMe/Assets.xcassets/colors/main/Primary100.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "1.000",
+          "green" : "0.996",
+          "red" : "0.922"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "1.000",
+          "green" : "1.000",
+          "red" : "1.000"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/TellingMe/tellingMe/Assets.xcassets/colors/main/Primary200.colorset/Contents.json
+++ b/TellingMe/tellingMe/Assets.xcassets/colors/main/Primary200.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "1.000",
+          "green" : "0.984",
+          "red" : "0.675"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "1.000",
+          "green" : "1.000",
+          "red" : "1.000"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/TellingMe/tellingMe/Assets.xcassets/colors/main/Primary300.colorset/Contents.json
+++ b/TellingMe/tellingMe/Assets.xcassets/colors/main/Primary300.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "1.000",
+          "green" : "0.976",
+          "red" : "0.561"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "1.000",
+          "green" : "1.000",
+          "red" : "1.000"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/TellingMe/tellingMe/Assets.xcassets/colors/main/Primary400.colorset/Contents.json
+++ b/TellingMe/tellingMe/Assets.xcassets/colors/main/Primary400.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "1.000",
+          "green" : "0.973",
+          "red" : "0.439"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "1.000",
+          "green" : "1.000",
+          "red" : "1.000"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/TellingMe/tellingMe/Assets.xcassets/colors/main/Primary500.colorset/Contents.json
+++ b/TellingMe/tellingMe/Assets.xcassets/colors/main/Primary500.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "1.000",
+          "green" : "0.953",
+          "red" : "0.078"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "1.000",
+          "green" : "1.000",
+          "red" : "1.000"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/TellingMe/tellingMe/Assets.xcassets/colors/main/Primary600.colorset/Contents.json
+++ b/TellingMe/tellingMe/Assets.xcassets/colors/main/Primary600.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.839",
+          "green" : "0.796",
+          "red" : "0.000"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "1.000",
+          "green" : "1.000",
+          "red" : "1.000"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/TellingMe/tellingMe/Assets.xcassets/colors/main/Primary700.colorset/Contents.json
+++ b/TellingMe/tellingMe/Assets.xcassets/colors/main/Primary700.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.722",
+          "green" : "0.682",
+          "red" : "0.000"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "1.000",
+          "green" : "1.000",
+          "red" : "1.000"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/TellingMe/tellingMe/Assets.xcassets/colors/main/Primary800.colorset/Contents.json
+++ b/TellingMe/tellingMe/Assets.xcassets/colors/main/Primary800.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.600",
+          "green" : "0.569",
+          "red" : "0.000"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "1.000",
+          "green" : "1.000",
+          "red" : "1.000"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/TellingMe/tellingMe/Assets.xcassets/colors/main/Primary900.colorset/Contents.json
+++ b/TellingMe/tellingMe/Assets.xcassets/colors/main/Primary900.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.478",
+          "green" : "0.455",
+          "red" : "0.000"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "1.000",
+          "green" : "1.000",
+          "red" : "1.000"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/TellingMe/tellingMe/data/moya+/Encodable+.swift
+++ b/TellingMe/tellingMe/data/moya+/Encodable+.swift
@@ -6,3 +6,15 @@
 //
 
 import Foundation
+
+extension Encodable {
+    func toDictionary() -> [String: Any] {
+        do {
+            let data = try JSONEncoder().encode(self)
+            let dic = try JSONSerialization.jsonObject(with: data, options: .allowFragments) as? [String: Any]
+            return dic ?? [:]
+        } catch {
+            return [:]
+        }
+    }
+}

--- a/TellingMe/tellingMe/data/moya+/NetworkLoggerPlugin.swift
+++ b/TellingMe/tellingMe/data/moya+/NetworkLoggerPlugin.swift
@@ -14,10 +14,10 @@ struct NetworkLoggerPlugin: PluginType {
             print("[HTTP Request] invalid request")
             return
         }
-        
+
         let url = httpRequest.description
         let method = httpRequest.httpMethod ?? "unknown method"
-        
+
         /// HTTP Request Summary
         var httpLog = """
                 [HTTP Request]
@@ -25,23 +25,23 @@ struct NetworkLoggerPlugin: PluginType {
                 TARGET: \(target)
                 METHOD: \(method)\n
                 """
-        
+
         /// HTTP Request Header
         httpLog.append("HEADER: [\n")
         httpRequest.allHTTPHeaderFields?.forEach {
             httpLog.append("\t\($0): \($1)\n")
         }
         httpLog.append("]\n")
-        
+
         /// HTTP Request Body
         if let body = httpRequest.httpBody, let bodyString = String(bytes: body, encoding: String.Encoding.utf8) {
             httpLog.append("BODY: \n\(bodyString)\n")
         }
         httpLog.append("[HTTP Request End]")
-        
+
         print(httpLog)
     }
-    
+
     func didReceive(_ result: Result<Response, MoyaError>, target: TargetType) {
         switch result {
         case let .success(response):
@@ -50,12 +50,12 @@ struct NetworkLoggerPlugin: PluginType {
             onFail(error, target: target)
         }
     }
-    
+
     func onSuceed(_ response: Response, target: TargetType, isFromError: Bool) {
         let request = response.request
         let url = request?.url?.absoluteString ?? "nil"
         let statusCode = response.statusCode
-        
+
         /// HTTP Response Summary
         var httpLog = """
                 [HTTP Response]
@@ -63,30 +63,30 @@ struct NetworkLoggerPlugin: PluginType {
                 URL: \(url)
                 STATUS CODE: \(statusCode)\n
                 """
-        
+
         /// HTTP Response Header
         httpLog.append("HEADER: [\n")
         response.response?.allHeaderFields.forEach {
             httpLog.append("\t\($0): \($1)\n")
         }
         httpLog.append("]\n")
-        
+
         /// HTTP Response Data
         httpLog.append("RESPONSE DATA: \n")
         if let responseString = String(bytes: response.data, encoding: String.Encoding.utf8) {
             httpLog.append("\(responseString)\n")
         }
         httpLog.append("[HTTP Response End]")
-        
+
         print(httpLog)
     }
-    
+
     func onFail(_ error: MoyaError, target: TargetType) {
         if let response = error.response {
             onSuceed(response, target: target, isFromError: true)
             return
         }
-        
+
         /// HTTP Error Summary
         var httpLog = """
                 [HTTP Error]
@@ -95,7 +95,7 @@ struct NetworkLoggerPlugin: PluginType {
                 """
         httpLog.append("MESSAGE: \(error.failureReason ?? error.errorDescription ?? "unknown error")\n")
         httpLog.append("[HTTP Error End]")
-        
+
         print(httpLog)
     }
 }

--- a/TellingMe/tellingMe/data/moya+/ResponseData.swift
+++ b/TellingMe/tellingMe/data/moya+/ResponseData.swift
@@ -8,63 +8,42 @@
 import Foundation
 import Moya
 
-struct Success<Data: Codable>: Codable {
-    let data: Data
-}
-
-struct Failure: Codable {
-    enum Case: Int, CaseIterable, Codable {
-        case badRequest = 100
-        case unauthorized = 101
-        case forbidden = 102
-        case notFound = 103
-        case jwtExpired = 104
-        case unsignedUser = 105
-        case nicknameDuplicate = 110
-        case userDuplicate = 111
-        case badMethod = 198
-        case internalServerError = 199
+struct ResponseData<Model: Codable> {
+    struct CommonResponse: Codable {
+        let result: Model
     }
 
-    let `case`: Case
-}
+    static func processResponse(_ result: Result<Response, MoyaError>) -> Result<Model?, Error> {
+        switch result {
+        case .success(let response):
+            do {
+                // status code가 200...299인 경우만 success로 체크 (아니면 예외발생)
+                _ = try response.filterSuccessfulStatusCodes()
 
-//struct ResponseData<Model: Codable> {
-//    struct CommonResponse: Codable {
-//        let result: Model
-//    }
-//
-//    static func processResponse(_ result: Result<Response, MoyaError>) -> Result<Model?, Error> {
-//        switch result {
-//        case .success(let response):
-//            do {
-//                // status code가 200...299인 경우만 success로 체크 (아니면 예외발생)
-//                _ = try response.filterSuccessfulStatusCodes()
-//
-//                let commonResponse = try JSONDecoder().decode(CommonResponse.self, from: response.data)
-//                return .success(commonResponse.result)
-//            } catch {
-//                return .failure(error)
-//            }
-//
-//        case .failure(let error):
-//            return .failure(error)
-//        }
-//    }
-//
-//    // CommonResponse 모델을 따르지 않는 모델을 처리하기 위한 함수
-//        static func processJSONResponse(_ result: Result<Response, MoyaError>) -> Result<Model?, Error> {
-//            switch result {
-//            case .success(let response):
-//                do {
-//                    let model = try JSONDecoder().decode(Model.self, from: response.data)
-//                    return .success(model)
-//                } catch {
-//                    return .failure(error)
-//                }
-//            case .failure(let error):
-//
-//                return .failure(error)
-//            }
-//        }
-//}
+                let commonResponse = try JSONDecoder().decode(CommonResponse.self, from: response.data)
+                return .success(commonResponse.result)
+            } catch {
+                return .failure(error)
+            }
+
+        case .failure(let error):
+            return .failure(error)
+        }
+    }
+
+    // CommonResponse 모델을 따르지 않는 모델을 처리하기 위한 함수
+        static func processJSONResponse(_ result: Result<Response, MoyaError>) -> Result<Model?, Error> {
+            switch result {
+            case .success(let response):
+                do {
+                    let model = try JSONDecoder().decode(Model.self, from: response.data)
+                    return .success(model)
+                } catch {
+                    return .failure(error)
+                }
+            case .failure(let error):
+
+                return .failure(error)
+            }
+        }
+}

--- a/TellingMe/tellingMe/data/moya+/ServiceError+.swift
+++ b/TellingMe/tellingMe/data/moya+/ServiceError+.swift
@@ -6,3 +6,30 @@
 //
 
 import Foundation
+import Moya
+
+// back-end 팀과 정의한 에러 내용
+enum ServiceError: Error {
+    case moyaError(MoyaError)
+    case invalidResponse(responseCode: Int, message: String)
+    case tokenExpired
+    case refreshTokenExpired
+    case duplicateLoggedIn(message: String)
+}
+
+extension ServiceError: LocalizedError {
+    var errorDescription: String? {
+        switch self {
+        case .moyaError(let moyaError):
+            return moyaError.localizedDescription
+        case let .invalidResponse(_, message):
+            return message
+        case .tokenExpired:
+            return "AccessToken Expired"
+        case .refreshTokenExpired:
+            return "RefreshToken Expired"
+        case let .duplicateLoggedIn(message):
+            return message
+        }
+    }
+}

--- a/TellingMe/tellingMe/data/moya+/TargetType+.swift
+++ b/TellingMe/tellingMe/data/moya+/TargetType+.swift
@@ -8,38 +8,12 @@
 import Foundation
 import Moya
 
-//protocol BaseTargetType: TargetType {
-//}
-//
-//extension BaseTargetType {
-//    var baseURL: URL {
-//        // Configuration을 통해 phase별 baseURL 설정 방법: https://ios-development.tistory.com/660
-////        guard let urlString = Bundle.main.object(forInfoDictionaryKey: "API_URL") as? String else { fatalError("API URL not defined")}
-////        gaurd let apiURL = URL(string: urlString) else { fatalError("URL is invalid") }
-//
-//        guard let apiURL = URL(string: Bundle.main.APIURL) else { fatalError("URL is invalid") }
-//        return apiURL
-//    }
-//
-////    var headers: [String: String]? {
-////        var header = ["Content-Type": "application/json"]
-////        let bundleVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? ""
-////        header["app-device-uuid"] = "uuid"
-////        header["app-device-model-name"] = UIDevice.current.name
-////        header["app-device-os-version"] = UIDevice.current.systemVersion
-////        header["app-device-device-manufacturer"] = "apple"
-////        header["app-version"] = bundleVersion
-////        header["app-timezone-id"] = TimeZone.current.identifier
-////        return header
-////    }
-//}
-
 extension TargetType {
     var baseURL: URL {
         guard let apiURL = URL(string: Bundle.main.APIURL) else { fatalError("URL is invalid") }
         return apiURL
     }
-    
+
     var sampleData: Data {
         return Data()
     }

--- a/TellingMe/tellingMe/data/test/DTO/TestDTO.swift
+++ b/TellingMe/tellingMe/data/test/DTO/TestDTO.swift
@@ -6,3 +6,12 @@
 //
 
 import Foundation
+import Moya
+
+struct TestRequest: Codable {
+
+}
+
+struct TestResponse: Codable {
+    let message: String
+}

--- a/TellingMe/tellingMe/data/test/DataSource/TestDataSource.swift
+++ b/TellingMe/tellingMe/data/test/DataSource/TestDataSource.swift
@@ -6,3 +6,43 @@
 //
 
 import Foundation
+import Moya
+
+enum TestAPITarget {
+    case test(TestRequest)
+}
+
+extension TestAPITarget: TargetType {
+    var headers: [String: String]? {
+        return nil
+    }
+
+    var task: Task {
+        .requestPlain
+    }
+
+    var path: String {
+        switch self {
+        case .test:
+            return ""
+        }
+    }
+
+    var method: Moya.Method {
+        return .get
+    }
+}
+
+struct TestAPI: Networkable {
+    typealias Target = TestAPITarget
+
+    /// page에 해당하는 User 정보 조회
+    static func getTest(request: TestRequest, completion: @escaping (_ succeed: TestResponse?, _ failed: Error?) -> Void) {
+        makeProvider().request(.test(request)) { result in
+            switch ResponseData<TestResponse>.processJSONResponse(result) {
+            case .success(let model): return completion(model, nil)
+            case .failure(let error): return completion(nil, error)
+            }
+        }
+    }
+}

--- a/TellingMe/tellingMe/presentation/Main.storyboard
+++ b/TellingMe/tellingMe/presentation/Main.storyboard
@@ -67,6 +67,18 @@
                                     <constraint firstItem="ARE-t6-1tL" firstAttribute="leading" secondItem="QFt-G8-PBH" secondAttribute="leading" constant="24" id="zZZ-ya-pe8"/>
                                 </constraints>
                             </view>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="4vi-Ao-5SZ">
+                                <rect key="frame" x="163" y="437.5" width="88" height="31"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" constant="88" id="Mih-Yx-xS0"/>
+                                    <constraint firstAttribute="height" constant="31" id="ftK-r6-b66"/>
+                                </constraints>
+                                <state key="normal" title="Button"/>
+                                <buttonConfiguration key="configuration" style="plain" title="API_TEST"/>
+                                <connections>
+                                    <action selector="clickAPITest:" destination="Y6W-OH-hqX" eventType="touchUpInside" id="z81-eV-U0r"/>
+                                </connections>
+                            </button>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="vDu-zF-Fre"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
@@ -75,6 +87,8 @@
                             <constraint firstItem="B9v-Ao-6gd" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" constant="24" id="BAN-e5-pkl"/>
                             <constraint firstItem="aEE-8m-he9" firstAttribute="top" secondItem="IN3-wA-9yU" secondAttribute="bottom" constant="8" id="QWS-AC-SDw"/>
                             <constraint firstItem="B9v-Ao-6gd" firstAttribute="top" secondItem="vDu-zF-Fre" secondAttribute="top" constant="104" id="Y88-PZ-Cj8"/>
+                            <constraint firstItem="4vi-Ao-5SZ" firstAttribute="centerY" secondItem="vDu-zF-Fre" secondAttribute="centerY" id="Ye3-M1-oU6"/>
+                            <constraint firstItem="4vi-Ao-5SZ" firstAttribute="centerX" secondItem="vDu-zF-Fre" secondAttribute="centerX" id="b4j-wq-vqk"/>
                             <constraint firstItem="IN3-wA-9yU" firstAttribute="leading" secondItem="B9v-Ao-6gd" secondAttribute="leading" id="f3u-Su-XuE"/>
                             <constraint firstAttribute="bottomMargin" secondItem="QFt-G8-PBH" secondAttribute="bottom" constant="-34" id="hWZ-mU-1eV"/>
                             <constraint firstItem="aEE-8m-he9" firstAttribute="leading" secondItem="B9v-Ao-6gd" secondAttribute="leading" id="tC4-7Q-WIm"/>

--- a/TellingMe/tellingMe/presentation/Main.storyboard
+++ b/TellingMe/tellingMe/presentation/Main.storyboard
@@ -8,11 +8,6 @@
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
-    <customFonts key="customFonts">
-        <array key="NanumSquareRoundOTFR.otf">
-            <string>NanumSquareRoundOTFR</string>
-        </array>
-    </customFonts>
     <scenes>
         <!--View Controller-->
         <scene sceneID="s0d-6b-0kx">
@@ -22,50 +17,75 @@
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <label hidden="YES" opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="하루 한 번," lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="B9v-Ao-6gd">
+                            <label hidden="YES" opaque="NO" userInteractionEnabled="NO" alpha="0.0" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="하루 한 번," lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="B9v-Ao-6gd" customClass="Headline2Regular" customModule="tellingMe" customModuleProvider="target">
                                 <rect key="frame" x="24" y="148" width="114" height="30"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="30" id="4JC-ai-tBU"/>
                                     <constraint firstAttribute="width" constant="114" id="hu7-DR-ehx"/>
                                 </constraints>
-                                <fontDescription key="fontDescription" name="NanumSquareRoundOTFR" family="NanumSquareRoundOTF" pointSize="26"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="26"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <label hidden="YES" opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="질문에 답변하며" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="IN3-wA-9yU">
+                            <label hidden="YES" opaque="NO" userInteractionEnabled="NO" alpha="0.0" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="질문에 답변하며" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="IN3-wA-9yU" customClass="Headline2Regular" customModule="tellingMe" customModuleProvider="target">
                                 <rect key="frame" x="24" y="186" width="173" height="30"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="173" id="8AZ-uN-NQO"/>
                                     <constraint firstAttribute="height" constant="30" id="kCP-YW-8G5"/>
                                 </constraints>
-                                <fontDescription key="fontDescription" name="NanumSquareRoundOTFR" family="NanumSquareRoundOTF" pointSize="26"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="26"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <label hidden="YES" opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="나를 깨닫는 시간" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="aEE-8m-he9">
+                            <label hidden="YES" opaque="NO" userInteractionEnabled="NO" alpha="0.0" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="나를 깨닫는 시간" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="aEE-8m-he9" customClass="Headline2Bold" customModule="tellingMe" customModuleProvider="target">
                                 <rect key="frame" x="24" y="224" width="179" height="30"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="179" id="TYS-7V-tO1"/>
                                     <constraint firstAttribute="height" constant="30" id="l0n-EE-Vkl"/>
                                 </constraints>
-                                <fontDescription key="fontDescription" name="NanumSquareRoundOTFR" family="NanumSquareRoundOTF" pointSize="26"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="26"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="QFt-G8-PBH">
                                 <rect key="frame" x="0.0" y="672" width="414" height="224"/>
                                 <subviews>
-                                    <stackView opaque="NO" contentMode="scaleToFill" ambiguous="YES" axis="vertical" distribution="equalSpacing" alignment="center" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="ARE-t6-1tL">
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" alignment="center" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="ARE-t6-1tL">
                                         <rect key="frame" x="24" y="28" width="366" height="124"/>
                                     </stackView>
                                 </subviews>
-                                <color key="backgroundColor" systemColor="systemGray6Color"/>
+                                <color key="backgroundColor" red="1" green="1" blue="1" alpha="0.44" colorSpace="custom" customColorSpace="sRGB"/>
                                 <constraints>
+                                    <constraint firstAttribute="bottom" secondItem="ARE-t6-1tL" secondAttribute="bottom" constant="72" id="96T-ii-0Fk"/>
                                     <constraint firstAttribute="trailing" secondItem="ARE-t6-1tL" secondAttribute="trailing" constant="24" id="YNf-y1-mzS"/>
                                     <constraint firstItem="ARE-t6-1tL" firstAttribute="top" secondItem="QFt-G8-PBH" secondAttribute="top" constant="28" id="b1O-Ht-joo"/>
                                     <constraint firstAttribute="height" constant="224" id="gVA-Oe-XAP"/>
                                     <constraint firstItem="ARE-t6-1tL" firstAttribute="leading" secondItem="QFt-G8-PBH" secondAttribute="leading" constant="24" id="zZZ-ya-pe8"/>
                                 </constraints>
+                                <userDefinedRuntimeAttributes>
+                                    <userDefinedRuntimeAttribute type="number" keyPath="cornerRadius">
+                                        <real key="value" value="50"/>
+                                    </userDefinedRuntimeAttribute>
+                                </userDefinedRuntimeAttributes>
+                            </view>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="W0u-Ld-Z1H">
+                                <rect key="frame" x="64.5" y="334" width="285" height="238"/>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" constant="285" id="9sJ-W3-ACh"/>
+                                    <constraint firstAttribute="height" constant="238" id="mVv-TQ-6GX"/>
+                                </constraints>
+                                <userDefinedRuntimeAttributes>
+                                    <userDefinedRuntimeAttribute type="number" keyPath="shadowRadius">
+                                        <real key="value" value="0.0"/>
+                                    </userDefinedRuntimeAttribute>
+                                    <userDefinedRuntimeAttribute type="number" keyPath="shadowOpacity">
+                                        <real key="value" value="0.0"/>
+                                    </userDefinedRuntimeAttribute>
+                                    <userDefinedRuntimeAttribute type="size" keyPath="shadowOffset">
+                                        <size key="value" width="0.0" height="0.0"/>
+                                    </userDefinedRuntimeAttribute>
+                                </userDefinedRuntimeAttributes>
                             </view>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="4vi-Ao-5SZ">
                                 <rect key="frame" x="163" y="437.5" width="88" height="31"/>
@@ -81,27 +101,31 @@
                             </button>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="vDu-zF-Fre"/>
-                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <color key="backgroundColor" systemColor="secondarySystemBackgroundColor"/>
                         <constraints>
+                            <constraint firstItem="4vi-Ao-5SZ" firstAttribute="centerX" secondItem="W0u-Ld-Z1H" secondAttribute="centerX" id="0ih-Xz-LaC"/>
                             <constraint firstItem="IN3-wA-9yU" firstAttribute="top" secondItem="B9v-Ao-6gd" secondAttribute="bottom" constant="8" id="1k4-YZ-V8K"/>
                             <constraint firstItem="B9v-Ao-6gd" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" constant="24" id="BAN-e5-pkl"/>
+                            <constraint firstItem="4vi-Ao-5SZ" firstAttribute="centerY" secondItem="W0u-Ld-Z1H" secondAttribute="centerY" id="G7k-Wi-a5b"/>
                             <constraint firstItem="aEE-8m-he9" firstAttribute="top" secondItem="IN3-wA-9yU" secondAttribute="bottom" constant="8" id="QWS-AC-SDw"/>
                             <constraint firstItem="B9v-Ao-6gd" firstAttribute="top" secondItem="vDu-zF-Fre" secondAttribute="top" constant="104" id="Y88-PZ-Cj8"/>
-                            <constraint firstItem="4vi-Ao-5SZ" firstAttribute="centerY" secondItem="vDu-zF-Fre" secondAttribute="centerY" id="Ye3-M1-oU6"/>
-                            <constraint firstItem="4vi-Ao-5SZ" firstAttribute="centerX" secondItem="vDu-zF-Fre" secondAttribute="centerX" id="b4j-wq-vqk"/>
                             <constraint firstItem="IN3-wA-9yU" firstAttribute="leading" secondItem="B9v-Ao-6gd" secondAttribute="leading" id="f3u-Su-XuE"/>
                             <constraint firstAttribute="bottomMargin" secondItem="QFt-G8-PBH" secondAttribute="bottom" constant="-34" id="hWZ-mU-1eV"/>
+                            <constraint firstItem="W0u-Ld-Z1H" firstAttribute="centerX" secondItem="vDu-zF-Fre" secondAttribute="centerX" id="nmv-C5-zkp"/>
                             <constraint firstItem="aEE-8m-he9" firstAttribute="leading" secondItem="B9v-Ao-6gd" secondAttribute="leading" id="tC4-7Q-WIm"/>
                             <constraint firstItem="vDu-zF-Fre" firstAttribute="trailing" secondItem="QFt-G8-PBH" secondAttribute="trailing" id="ugs-7Q-z3y"/>
+                            <constraint firstItem="W0u-Ld-Z1H" firstAttribute="centerY" secondItem="vDu-zF-Fre" secondAttribute="centerY" id="utO-qa-MZx"/>
                             <constraint firstItem="QFt-G8-PBH" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" id="zrl-W3-JIB"/>
                         </constraints>
                     </view>
                     <nil key="simulatedTopBarMetrics"/>
                     <connections>
-                        <outlet property="label1" destination="B9v-Ao-6gd" id="SmL-gg-MOs"/>
-                        <outlet property="label2" destination="IN3-wA-9yU" id="pQQ-xV-Jt9"/>
-                        <outlet property="label3" destination="aEE-8m-he9" id="4Ao-Wc-c7Y"/>
+                        <outlet property="backgroundView" destination="5EZ-qb-Rvc" id="uuI-zm-j2s"/>
+                        <outlet property="gradientView" destination="W0u-Ld-Z1H" id="zwh-vT-jF2"/>
                         <outlet property="loginStackView" destination="ARE-t6-1tL" id="GCM-OY-Csn"/>
+                        <outletCollection property="labels" destination="B9v-Ao-6gd" collectionClass="NSMutableArray" id="8xV-rB-J42"/>
+                        <outletCollection property="labels" destination="IN3-wA-9yU" collectionClass="NSMutableArray" id="C1p-1Z-fm4"/>
+                        <outletCollection property="labels" destination="aEE-8m-he9" collectionClass="NSMutableArray" id="UAl-eA-UK7"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Ief-a0-LHa" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
@@ -109,12 +133,17 @@
             <point key="canvasLocation" x="60.869565217391312" y="105.80357142857143"/>
         </scene>
     </scenes>
+    <designables>
+        <designable name="B9v-Ao-6gd">
+            <size key="intrinsicContentSize" width="107.5" height="31.5"/>
+        </designable>
+    </designables>
     <resources>
+        <systemColor name="secondarySystemBackgroundColor">
+            <color red="0.94901960784313721" green="0.94901960784313721" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-        </systemColor>
-        <systemColor name="systemGray6Color">
-            <color red="0.94901960784313721" green="0.94901960784313721" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
     </resources>
 </document>

--- a/TellingMe/tellingMe/presentation/ViewController.swift
+++ b/TellingMe/tellingMe/presentation/ViewController.swift
@@ -10,6 +10,7 @@ import AuthenticationServices
 import KakaoSDKCommon
 import KakaoSDKAuth
 import KakaoSDKUser
+import Moya
 
 @IBDesignable
 class ViewController: UIViewController {
@@ -53,6 +54,17 @@ class ViewController: UIViewController {
       authorizationController.delegate = self
       authorizationController.presentationContextProvider = self
       authorizationController.performRequests()
+    }
+
+    @IBAction func clickAPITest(_ sender: Any) {
+        let request = TestRequest()
+        TestAPI.getTest(request: request) { response, error in
+            guard let response = response else {
+                print(error ?? #function)
+                return
+            }
+            print(response)
+        }
     }
 
     override func viewDidLoad() {

--- a/TellingMe/tellingMe/presentation/ViewController.swift
+++ b/TellingMe/tellingMe/presentation/ViewController.swift
@@ -14,10 +14,10 @@ import Moya
 
 @IBDesignable
 class ViewController: UIViewController {
-    @IBOutlet weak var label1: UILabel!
-    @IBOutlet weak var label2: UILabel!
-    @IBOutlet weak var label3: UILabel!
+    @IBOutlet var backgroundView: UIView!
     @IBOutlet weak var loginStackView: UIStackView!
+    @IBOutlet weak var gradientView: UIView!
+    @IBOutlet var labels: [UILabel]!
 
     @objc
     func clickKakaoLogin() {
@@ -46,14 +46,14 @@ class ViewController: UIViewController {
 
     @objc
     func clickAppleLogin() {
-      let appleIDProvider = ASAuthorizationAppleIDProvider()
-      let request = appleIDProvider.createRequest()
-      request.requestedScopes = [.fullName, .email]
+        let appleIDProvider = ASAuthorizationAppleIDProvider()
+        let request = appleIDProvider.createRequest()
+        request.requestedScopes = [.fullName, .email]
 
-      let authorizationController = ASAuthorizationController(authorizationRequests: [request])
-      authorizationController.delegate = self
-      authorizationController.presentationContextProvider = self
-      authorizationController.performRequests()
+        let authorizationController = ASAuthorizationController(authorizationRequests: [request])
+        authorizationController.delegate = self
+        authorizationController.presentationContextProvider = self
+        authorizationController.performRequests()
     }
 
     @IBAction func clickAPITest(_ sender: Any) {
@@ -69,6 +69,7 @@ class ViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
+        setUI()
         setLoginButtons()
     }
 
@@ -76,13 +77,20 @@ class ViewController: UIViewController {
         labelAnimate()
     }
 
+    func setUI() {
+        gradientView.frame = CGRect(x: 0, y: 0, width: 285, height: 238)
+        gradientView.setShadow()
+        gradientView.setGradient(color1: UIColor(red: 0.992, green: 0.859, blue: 0.573, alpha: 1), color2: UIColor(red: 0.82, green: 0.992, blue: 1, alpha: 1))
+    }
+
     func setLoginButtons() {
         let kakaoButton: UIButton = {
             let button = UIButton()
-
-            button.titleLabel?.text = "카카오 계정으로 시작하기"
+            button.setTitle("카카오로 계속하기", for: .normal)
             button.addTarget(self, action: #selector(clickKakaoLogin), for: .touchDown)
-            button.backgroundColor = .black
+            button.backgroundColor = UIColor(red: 0.996, green: 0.898, blue: 0, alpha: 1)
+            button.setTitleColor(UIColor(red: 0, green: 0, blue: 0, alpha: 1), for: .normal)
+            button.titleLabel?.font = UIFont(name: "NanumSquareRoundOTFR", size: 15)
             button.translatesAutoresizingMaskIntoConstraints = false
             return button
         }()
@@ -90,41 +98,37 @@ class ViewController: UIViewController {
         let appleButton: ASAuthorizationAppleIDButton = {
             let button = ASAuthorizationAppleIDButton(type: .continue, style: .black)
             button.addTarget(self, action: #selector(clickAppleLogin), for: .touchDown)
-            button.translatesAutoresizingMaskIntoConstraints = false
             return button
         }()
 
-        kakaoButton.heightAnchor.constraint(equalToConstant: 54).isActive = true
-        appleButton.heightAnchor.constraint(equalToConstant: 54).isActive = true
         loginStackView.addArrangedSubview(kakaoButton)
         loginStackView.addArrangedSubview(appleButton)
+
+        kakaoButton.heightAnchor.constraint(equalToConstant: 54).isActive = true
+        kakaoButton.widthAnchor.constraint(equalTo: loginStackView.widthAnchor).isActive = true
+        appleButton.heightAnchor.constraint(equalToConstant: 54).isActive = true
+        appleButton.widthAnchor.constraint(equalTo: loginStackView.widthAnchor).isActive = true
+        loginStackView.layoutIfNeeded()
 
         kakaoButton.layer.cornerRadius = kakaoButton.frame.height / 2
         appleButton.layer.cornerRadius = appleButton.frame.height / 2
     }
 
     func labelAnimate() {
-        let now = DispatchTime.now()
-        DispatchQueue.main.asyncAfter(deadline: now + 1) {
-            self.pushAnimate(label: self.label1)
-        }
-        DispatchQueue.main.asyncAfter(deadline: now + 2) {
-            self.pushAnimate(label: self.label2)
-        }
-        DispatchQueue.main.asyncAfter(deadline: now + 3) {
-            self.label3.font = UIFont(name: "NanumSquareRoundOTFB", size: 26)
-            self.pushAnimate(label: self.label3)
+        for (index, label) in labels.enumerated() {
+            Timer.scheduledTimer(withTimeInterval: TimeInterval(1*index), repeats: false) { _ in
+                self.pushAnimate(label: label)
+            }
         }
     }
 
     private func pushAnimate(label: UILabel) {
-        label.isHidden = false
-        let transition = CATransition()
-        transition.duration = 0.5
-        transition.timingFunction = .init(name: .easeInEaseOut)
-        transition.type = .push
-        transition.subtype = .fromTop
-        label.layer.add(transition, forKey: CATransitionType.push.rawValue)
+        UILabel.animate(withDuration: 0.5,
+                        animations: { label.isHidden = false
+            label.alpha = 1
+            label.frame.origin.y -= 20
+        },
+                        completion: nil)
     }
 }
 
@@ -139,6 +143,6 @@ extension ViewController: ASAuthorizationControllerDelegate, ASAuthorizationCont
     }
 
     func authorizationController(controller: ASAuthorizationController, didCompleteWithError error: Error) {
-      // Handle error.
+        // Handle error.
     }
 }

--- a/TellingMe/tellingMe/util/custom/BodyLabel.swift
+++ b/TellingMe/tellingMe/util/custom/BodyLabel.swift
@@ -1,0 +1,72 @@
+//
+//  BodyLabel.swift
+//  tellingMe
+//
+//  Created by 마경미 on 21.03.23.
+//
+
+import UIKit
+
+class Body1Bold: UILabel {
+    required init?(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+        initializeLabel()
+    }
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        initializeLabel()
+    }
+
+    func initializeLabel() {
+        self.font = UIFont(name: "NanumSquareRoundOTF-Bold", size: 15)
+    }
+}
+
+class Body1Regular: UILabel {
+    required init?(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+        initializeLabel()
+    }
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        initializeLabel()
+    }
+
+    func initializeLabel() {
+        self.font = UIFont(name: "NanumSquareRoundOTF-Regular", size: 15)
+    }
+}
+
+class Body2Bold: UILabel {
+    required init?(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+        initializeLabel()
+    }
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        initializeLabel()
+    }
+
+    func initializeLabel() {
+        self.font = UIFont(name: "NanumSquareRoundOTF-Bold", size: 14)
+    }
+}
+
+class Body2Regular: UILabel {
+    required init?(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+        initializeLabel()
+    }
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        initializeLabel()
+    }
+
+    func initializeLabel() {
+        self.font = UIFont(name: "NanumSquareRoundOTF-Regular", size: 14)
+    }
+}

--- a/TellingMe/tellingMe/util/custom/CaptionLabel.swift
+++ b/TellingMe/tellingMe/util/custom/CaptionLabel.swift
@@ -1,0 +1,40 @@
+//
+//  CaptionLabel.swift
+//  tellingMe
+//
+//  Created by 마경미 on 21.03.23.
+//
+
+import UIKit
+
+class CaptionLabelLight: UILabel {
+    required init?(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+        initializeLabel()
+    }
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        initializeLabel()
+    }
+
+    func initializeLabel() {
+        self.font = UIFont(name: "NanumSquareRoundOTF-Light", size: 12)
+    }
+}
+
+class CpationLabelRegular: UILabel {
+    required init?(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+        initializeLabel()
+    }
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        initializeLabel()
+    }
+
+    func initializeLabel() {
+        self.font = UIFont(name: "NanumSquareRoundOTF-Regular", size: 12)
+    }
+}

--- a/TellingMe/tellingMe/util/custom/HeadlineLabel.swift
+++ b/TellingMe/tellingMe/util/custom/HeadlineLabel.swift
@@ -19,7 +19,7 @@ class Headline2Bold: UILabel {
     }
 
     func initializeLabel() {
-        self.font = UIFont(name: "NanumSquareRoundOTF-Bold", size: 26)
+        self.font = UIFont(name: "NanumSquareRoundOTFB", size: 26)
     }
 }
 
@@ -35,7 +35,7 @@ class Headline2Regular: UILabel {
     }
 
     func initializeLabel() {
-        self.font = UIFont(name: "NanumSquareRoundOTF-Regular", size: 26)
+        self.font = UIFont(name: "NanumSquareRoundOTFR", size: 26)
     }
 }
 
@@ -51,7 +51,7 @@ class Headline3Bold: UILabel {
     }
 
     func initializeLabel() {
-        self.font = UIFont(name: "NanumSquareRoundOTF-Bold", size: 19)
+        self.font = UIFont(name: "NanumSquareRoundOTFB", size: 19)
     }
 }
 
@@ -67,7 +67,7 @@ class Headline3Regular: UILabel {
     }
 
     func initializeLabel() {
-        self.font = UIFont(name: "NanumSquareRoundOTF-Regular", size: 19)
+        self.font = UIFont(name: "NanumSquareRoundOTFR", size: 19)
     }
 }
 
@@ -83,7 +83,7 @@ class Headline4Bold: UILabel {
     }
 
     func initializeLabel() {
-        self.font = UIFont(name: "NanumSquareRoundOTF-Bold", size: 17)
+        self.font = UIFont(name: "NanumSquareRoundOTFB", size: 17)
     }
 }
 
@@ -99,6 +99,6 @@ class Headline4Regular: UILabel {
     }
 
     func initializeLabel() {
-        self.font = UIFont(name: "NanumSquareRoundOTF-Regular", size: 17)
+        self.font = UIFont(name: "NanumSquareRoundOTFR", size: 17)
     }
 }

--- a/TellingMe/tellingMe/util/custom/HeadlineLabel.swift
+++ b/TellingMe/tellingMe/util/custom/HeadlineLabel.swift
@@ -1,0 +1,104 @@
+//
+//  Headline.swift
+//  tellingMe
+//
+//  Created by 마경미 on 21.03.23.
+//
+
+import UIKit
+
+class Headline2Bold: UILabel {
+    required init?(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+        initializeLabel()
+    }
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        initializeLabel()
+    }
+
+    func initializeLabel() {
+        self.font = UIFont(name: "NanumSquareRoundOTF-Bold", size: 26)
+    }
+}
+
+class Headline2Regular: UILabel {
+    required init?(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+        initializeLabel()
+    }
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        initializeLabel()
+    }
+
+    func initializeLabel() {
+        self.font = UIFont(name: "NanumSquareRoundOTF-Regular", size: 26)
+    }
+}
+
+class Headline3Bold: UILabel {
+    required init?(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+        initializeLabel()
+    }
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        initializeLabel()
+    }
+
+    func initializeLabel() {
+        self.font = UIFont(name: "NanumSquareRoundOTF-Bold", size: 19)
+    }
+}
+
+class Headline3Regular: UILabel {
+    required init?(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+        initializeLabel()
+    }
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        initializeLabel()
+    }
+
+    func initializeLabel() {
+        self.font = UIFont(name: "NanumSquareRoundOTF-Regular", size: 19)
+    }
+}
+
+class Headline4Bold: UILabel {
+    required init?(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+        initializeLabel()
+    }
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        initializeLabel()
+    }
+
+    func initializeLabel() {
+        self.font = UIFont(name: "NanumSquareRoundOTF-Bold", size: 17)
+    }
+}
+
+class Headline4Regular: UILabel {
+    required init?(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+        initializeLabel()
+    }
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        initializeLabel()
+    }
+
+    func initializeLabel() {
+        self.font = UIFont(name: "NanumSquareRoundOTF-Regular", size: 17)
+    }
+}

--- a/TellingMe/tellingMe/util/extension/Bundle+.swift
+++ b/TellingMe/tellingMe/util/extension/Bundle+.swift
@@ -14,4 +14,11 @@ extension Bundle {
         guard let key = resource["kakaoNativeAppKey"] as? String else { fatalError("kakao Native App Key를 확인해주세요.")}
         return key
     }
+
+    var APIURL: String {
+        guard let file = self.path(forResource: "KeyList", ofType: "plist") else { return "" }
+        guard let resource = NSDictionary(contentsOfFile: file) else { return "" }
+        guard let key = resource["API_URL"] as? String else { fatalError("API URL을 확인해주세요.")}
+        return key
+    }
 }

--- a/TellingMe/tellingMe/util/extension/UIView+.swift
+++ b/TellingMe/tellingMe/util/extension/UIView+.swift
@@ -9,12 +9,32 @@ import UIKit
 
 extension UIView {
     func setGradient(color1: UIColor, color2: UIColor) {
+        let shapes = UIView()
+        shapes.frame = self.frame
+        shapes.clipsToBounds = true
+        self.addSubview(shapes)
+
         let gradient: CAGradientLayer = CAGradientLayer()
         gradient.colors = [color1.cgColor, color2.cgColor]
         gradient.locations = [0.0, 1.0]
-        gradient.startPoint = CGPoint(x: 0.0, y: 1.0)
-        gradient.endPoint = CGPoint(x: 1.0, y: 1.0)
-        gradient.frame = bounds
-        layer.addSublayer(gradient)
+        gradient.startPoint = CGPoint(x: 0.25, y: 0.5)
+        gradient.endPoint = CGPoint(x: 0.75, y: 0.5)
+        gradient.transform = CATransform3DMakeAffineTransform(CGAffineTransform(a: 1.03, b: -0.76, c: 0.53, d: 1.03, tx: -0.26, ty: 0.4))
+        gradient.bounds = self.bounds.insetBy(dx: -0.5*self.bounds.size.width, dy: -0.5*self.bounds.size.height)
+        gradient.position = self.center
+        shapes.layer.addSublayer(gradient)
+    }
+
+    func setShadow() {
+        let shadowPath: UIBezierPath = UIBezierPath(roundedRect: self.bounds, cornerRadius: 0)
+        let layer = CALayer()
+        layer.shadowPath = shadowPath.cgPath
+        layer.shadowColor = UIColor(red: 0.902, green: 0.929, blue: 0.8, alpha: 1).cgColor
+        layer.shadowOpacity = 1
+        layer.shadowRadius = 20
+        layer.shadowOffset = CGSize(width: 0, height: 4)
+        layer.bounds = self.bounds
+        layer.position = self.center
+        self.layer.addSublayer(layer)
     }
 }


### PR DESCRIPTION
### 📃 전달 사항
style guide에 따라 재사용성을 위한 코드 정리 진행
- shadow, gradient는 uiview extension을 통해서 정리 ( 이후에 색상 또는 위치 등의 변경이 생기면 함수 파라미터 수정)
- 색상 라벨 정의
- 폰트 라벨 정의 ( 라벨 생성하고 클래스 이름에 재사용 클래스 넣어주기만 하면 된다)


### ✔ 진행사항
- [x] 폰트 라벨 커스텀
- [x] 색상 정의
- [x] gradient extension
- [x] shadow extension


### 🔴 ETC
기타 사항을 적어주세요.
실제 개발 기간 : 2시간


### 💻 개발환경
macOS: Monterey 12.0.1
iOS: iphone 11 pro simulator


<hr>

closes: #11 
