### PR TITLE
[feedback] : 1st_feedback-67

### DIFF
--- a/TellingMe/tellingMe/data/user/dto/MyInfoRepository.swift
+++ b/TellingMe/tellingMe/data/user/dto/MyInfoRepository.swift
@@ -24,7 +24,7 @@ extension MyInfoViewController {
             }
         }
     }
-    
+
     func updateUserInfo() {
         let request = UpdateUserInfoRequest(birthDate: viewModel.makeBirthData(), gender: viewModel.gender, job: viewModel.job, jobInfo: viewModel.jobInfo, mbti: viewModel.mbti, nickname: viewModel.nickname, purpose: viewModel.purpose.intArraytoString())
         UserAPI.updateUserInfo(request: request) { result in

--- a/TellingMe/tellingMe/presentation/answer/Answer.storyboard
+++ b/TellingMe/tellingMe/presentation/answer/Answer.storyboard
@@ -142,7 +142,7 @@
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="J7T-o1-yTF">
                                         <rect key="frame" x="0.0" y="0.0" width="393" height="28"/>
                                         <subviews>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="/ 500" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="QVa-0t-zqo" customClass="CaptionLabelBold" customModule="tellingMe" customModuleProvider="target">
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="/ 300" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="QVa-0t-zqo" customClass="CaptionLabelBold" customModule="tellingMe" customModuleProvider="target">
                                                 <rect key="frame" x="328" y="3.6666666666666288" width="40" height="21"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <color key="textColor" name="Gray6"/>
@@ -484,7 +484,7 @@
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="u5d-s8-jrB">
                                         <rect key="frame" x="0.0" y="0.0" width="393" height="28"/>
                                         <subviews>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="/ 500" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="27F-tQ-Z7H" customClass="CaptionLabelBold" customModule="tellingMe" customModuleProvider="target">
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="/ 300" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="27F-tQ-Z7H" customClass="CaptionLabelBold" customModule="tellingMe" customModuleProvider="target">
                                                 <rect key="frame" x="328" y="3.6666666666666288" width="40" height="21"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <color key="textColor" name="Gray6"/>

--- a/TellingMe/tellingMe/presentation/answer/viewController/AnswerViewController+.swift
+++ b/TellingMe/tellingMe/presentation/answer/viewController/AnswerViewController+.swift
@@ -53,10 +53,10 @@ extension AnswerViewController: UITextViewDelegate {
     }
 
     func textViewDidEndEditing(_ textView: UITextView) {
-        if textView.text.count > 500 {
+        if textView.text.count > 300 {
         // 글자수 제한에 걸리면 마지막 글자를 삭제함.
             textView.text.removeLast()
-            countTextLabel.text = "\(500)"
+            countTextLabel.text = "\(300)"
         }
     }
 }

--- a/TellingMe/tellingMe/presentation/answer/viewController/AnswerViewController.swift
+++ b/TellingMe/tellingMe/presentation/answer/viewController/AnswerViewController.swift
@@ -46,10 +46,10 @@ class AnswerViewController: UIViewController, ModalActionDelegate {
     }
 
     override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
-        if answerTextView.text.count > 500 {
+        if answerTextView.text.count > 300 {
         // 글자수 제한에 걸리면 마지막 글자를 삭제함.
             answerTextView.text.removeLast()
-            countTextLabel.text = "\(500)"
+            countTextLabel.text = "\(300)"
         }
          answerTextView.resignFirstResponder()
      }
@@ -79,20 +79,22 @@ class AnswerViewController: UIViewController, ModalActionDelegate {
     }
 
     @IBAction func clickComplete(_ sender: UIButton) {
-        if answerTextView.text.count > 500 {
+        if answerTextView.text.count > 300 {
         // 글자수 제한에 걸리면 마지막 글자를 삭제함.
             answerTextView.text.removeLast()
-            countTextLabel.text = "\(500)"
+            countTextLabel.text = "\(300)"
+        } else if answerTextView.text.count <= 4 {
+            self.showToast(message: "4글자 이상 작성해주세요")
+        } else {
+            let storyboard = UIStoryboard(name: "Modal", bundle: nil)
+            guard let vc = storyboard.instantiateViewController(identifier: "modalRegisterAnswer") as? ModalViewController else {
+                return
+            }
+            vc.delegate = self
+            vc.modalPresentationStyle = .overCurrentContext
+            vc.modalTransitionStyle = .coverVertical
+            self.present(vc, animated: true)
         }
-
-        let storyboard = UIStoryboard(name: "Modal", bundle: nil)
-        guard let vc = storyboard.instantiateViewController(identifier: "modalRegisterAnswer") as? ModalViewController else {
-            return
-        }
-        vc.delegate = self
-        vc.modalPresentationStyle = .overCurrentContext
-        vc.modalTransitionStyle = .coverVertical
-        self.present(vc, animated: true)
     }
 
     @IBAction func presentEotionView(_ sender: UIButton) {

--- a/TellingMe/tellingMe/presentation/answerList/AnswerListViewModel.swift
+++ b/TellingMe/tellingMe/presentation/answerList/AnswerListViewModel.swift
@@ -14,7 +14,7 @@ class AnswerListViewModel {
     var month = Date().monthFormat()
 
     var yearArray = [2023]
-    var monthArray = Array(1...13)
+    var monthArray = Array(1...12)
     let standardYear = 2023
 
     init() {

--- a/TellingMe/tellingMe/presentation/common/modal/Modal.storyboard
+++ b/TellingMe/tellingMe/presentation/common/modal/Modal.storyboard
@@ -214,7 +214,7 @@
                                             <button opaque="NO" tag="1" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Ogn-Cm-jxg" customClass="SecondaryTextButton" customModule="tellingMe" customModuleProvider="target">
                                                 <rect key="frame" x="159" y="0.0" width="144" height="55"/>
                                                 <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
-                                                <state key="normal" title="저장하기"/>
+                                                <state key="normal" title="탈퇴하기"/>
                                                 <connections>
                                                     <action selector="clickButton:" destination="Ma7-pE-xzB" eventType="touchUpInside" id="cfx-nm-85B"/>
                                                 </connections>

--- a/TellingMe/tellingMe/presentation/common/nicknameInput/NickNameInputViewController.swift
+++ b/TellingMe/tellingMe/presentation/common/nicknameInput/NickNameInputViewController.swift
@@ -24,7 +24,7 @@ class NickNameInputViewController: UIViewController {
     func offKeyboard() {
         input.hiddenKeyboard()
     }
-    
+
     func setText(text: String?) {
         input.inputBox.text = text
     }

--- a/TellingMe/tellingMe/presentation/home/Home.storyboard
+++ b/TellingMe/tellingMe/presentation/home/Home.storyboard
@@ -283,6 +283,9 @@
         <designable name="QYq-Da-bcO">
             <size key="intrinsicContentSize" width="41.5" height="20.5"/>
         </designable>
+        <designable name="Tpz-oD-GK7">
+            <size key="intrinsicContentSize" width="68.5" height="20.5"/>
+        </designable>
         <designable name="lH9-tL-FdQ">
             <size key="intrinsicContentSize" width="41.5" height="20.5"/>
         </designable>

--- a/TellingMe/tellingMe/presentation/setting/Setting.storyboard
+++ b/TellingMe/tellingMe/presentation/setting/Setting.storyboard
@@ -695,7 +695,7 @@
                                 </constraints>
                                 <color key="tintColor" name="Primary700"/>
                                 <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
-                                <state key="normal" image="checkmark" catalog="system">
+                                <state key="normal">
                                     <color key="titleColor" red="1" green="0.60392156860000001" blue="0.61960784310000006" alpha="1" colorSpace="calibratedRGB"/>
                                 </state>
                                 <userDefinedRuntimeAttributes>
@@ -709,8 +709,11 @@
                                         <color key="value" name="Primary700"/>
                                     </userDefinedRuntimeAttribute>
                                 </userDefinedRuntimeAttributes>
+                                <connections>
+                                    <action selector="clickAgree:" destination="Z2X-or-Oak" eventType="touchUpInside" id="7SI-dJ-fbF"/>
+                                </connections>
                             </button>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="MxA-UC-m94" customClass="SecondaryTextButton" customModule="tellingMe" customModuleProvider="target">
+                            <button opaque="NO" contentMode="scaleToFill" enabled="NO" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="MxA-UC-m94" customClass="SecondaryTextButton" customModule="tellingMe" customModuleProvider="target">
                                 <rect key="frame" x="25" y="593.33333333333337" width="343" height="55"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="55" id="SUh-ae-JYv"/>
@@ -743,6 +746,7 @@
                         </constraints>
                     </view>
                     <connections>
+                        <outlet property="checkButton" destination="cD0-E0-vDe" id="gUg-c9-WGK"/>
                         <outlet property="headerView" destination="xmD-ef-y1m" id="Mbp-3g-0H5"/>
                         <outlet property="withdrawalButton" destination="MxA-UC-m94" id="YTV-jy-lSv"/>
                     </connections>
@@ -765,38 +769,27 @@
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" reuseIdentifier="settingTableViewCell" id="mwJ-0D-U9e" customClass="SettingTableViewCell" customModule="tellingMe" customModuleProvider="target">
                                         <rect key="frame" x="0.0" y="50" width="393" height="60"/>
                                         <autoresizingMask key="autoresizingMask"/>
-                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="mwJ-0D-U9e" id="z32-Ih-zaR" customClass="SettingTableViewCell" customModule="tellingMe" customModuleProvider="target">
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="mwJ-0D-U9e" id="z32-Ih-zaR">
                                             <rect key="frame" x="0.0" y="0.0" width="393" height="60"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="XDz-gp-EtI">
-                                                    <rect key="frame" x="0.0" y="0.0" width="393" height="60"/>
-                                                    <subviews>
-                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="푸쉬 알림 동의" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="sIo-Gj-73X" customClass="Body1Regular" customModule="tellingMe" customModuleProvider="target">
-                                                            <rect key="frame" x="25" y="21" width="97" height="21"/>
-                                                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                            <nil key="textColor"/>
-                                                            <nil key="highlightedColor"/>
-                                                        </label>
-                                                        <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="mmI-2S-3ZL">
-                                                            <rect key="frame" x="309" y="18" width="51" height="31"/>
-                                                            <color key="onTintColor" name="Logo"/>
-                                                        </switch>
-                                                    </subviews>
-                                                    <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                                    <constraints>
-                                                        <constraint firstAttribute="trailing" secondItem="mmI-2S-3ZL" secondAttribute="trailing" constant="35" id="4vD-4t-x7n"/>
-                                                        <constraint firstItem="mmI-2S-3ZL" firstAttribute="top" secondItem="XDz-gp-EtI" secondAttribute="top" constant="18" id="9lV-XQ-bRo"/>
-                                                        <constraint firstItem="sIo-Gj-73X" firstAttribute="top" secondItem="XDz-gp-EtI" secondAttribute="top" constant="21" id="FR5-Bm-cj6"/>
-                                                        <constraint firstItem="sIo-Gj-73X" firstAttribute="leading" secondItem="XDz-gp-EtI" secondAttribute="leading" constant="25" id="NvK-FR-q0P"/>
-                                                    </constraints>
-                                                </view>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="푸시 알림 동의" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="sIo-Gj-73X" customClass="Body1Regular" customModule="tellingMe" customModuleProvider="target">
+                                                    <rect key="frame" x="25" y="20" width="97" height="20.333333333333329"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="D2Q-SN-ZdJ">
+                                                    <rect key="frame" x="319" y="14.666666666666664" width="51" height="31"/>
+                                                    <rect key="contentStretch" x="0.0" y="0.0" width="0.80000000000000004" height="0.75"/>
+                                                    <color key="onTintColor" name="Logo"/>
+                                                </switch>
                                             </subviews>
                                             <constraints>
-                                                <constraint firstItem="XDz-gp-EtI" firstAttribute="top" secondItem="z32-Ih-zaR" secondAttribute="top" id="8So-UQ-DsH"/>
-                                                <constraint firstAttribute="bottom" secondItem="XDz-gp-EtI" secondAttribute="bottom" id="Ih5-E2-qmU"/>
-                                                <constraint firstItem="XDz-gp-EtI" firstAttribute="leading" secondItem="z32-Ih-zaR" secondAttribute="leading" id="dOv-Wo-Gla"/>
-                                                <constraint firstAttribute="trailing" secondItem="XDz-gp-EtI" secondAttribute="trailing" id="gKQ-4i-vCa"/>
+                                                <constraint firstItem="sIo-Gj-73X" firstAttribute="leading" secondItem="z32-Ih-zaR" secondAttribute="leading" constant="25" id="8e3-AU-pU4"/>
+                                                <constraint firstAttribute="trailing" secondItem="D2Q-SN-ZdJ" secondAttribute="trailing" constant="25" id="ZWZ-7H-g58"/>
+                                                <constraint firstItem="D2Q-SN-ZdJ" firstAttribute="centerY" secondItem="sIo-Gj-73X" secondAttribute="centerY" id="lNG-YW-ooS"/>
+                                                <constraint firstItem="sIo-Gj-73X" firstAttribute="centerY" secondItem="z32-Ih-zaR" secondAttribute="centerY" id="phR-Xg-U5N"/>
                                             </constraints>
                                         </tableViewCellContentView>
                                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
@@ -1057,7 +1050,6 @@
         </designable>
     </designables>
     <resources>
-        <image name="checkmark" catalog="system" width="128" height="114"/>
         <image name="chevron.right" catalog="system" width="97" height="128"/>
         <namedColor name="Gray7">
             <color red="0.30199998617172241" green="0.32499998807907104" blue="0.31000000238418579" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>

--- a/TellingMe/tellingMe/presentation/setting/main/viewController/WithdrawalViewController.swift
+++ b/TellingMe/tellingMe/presentation/setting/main/viewController/WithdrawalViewController.swift
@@ -8,13 +8,27 @@
 import UIKit
 
 class WithdrawalViewController: SettingViewController {
-
+    @IBOutlet weak var checkButton: UIButton!
     @IBOutlet weak var withdrawalButton: SecondaryTextButton!
     override func viewDidLoad() {
         super.viewDidLoad()
+        checkButton.setImage(UIImage(systemName: "checkmark"), for: .selected)
+        withdrawalButton.isEnabled = false
         headerView.setTitle(title: "회원 탈퇴")
     }
     
+    @IBAction func clickAgree(_ sender: UIButton) {
+        sender.isSelected.toggle()
+        if sender.isSelected {
+            // agree
+            withdrawalButton.isEnabled = true
+
+        } else {
+            // not agree
+            withdrawalButton.isEnabled = false
+        }
+    }
+
     @IBAction func clickWithdrawal(_ sender: UIButton) {
         let storyboard = UIStoryboard(name: "Modal", bundle: nil)
         guard let vc = storyboard.instantiateViewController(withIdentifier: "withdrawalModal") as? ModalViewController else { return }

--- a/TellingMe/tellingMe/presentation/setting/myInfo/viewController/MyInfoViewController.swift
+++ b/TellingMe/tellingMe/presentation/setting/myInfo/viewController/MyInfoViewController.swift
@@ -20,7 +20,7 @@ class MyInfoViewController: DropDownViewController {
     let purposeVC = ChipPurposeViewController()
     let jobVC = ChipJobViewController()
     let genderVC = ChipGenderViewController()
-    
+
     let completedButton: UIButton = {
        let button = UIButton()
         button.setTitle("완료", for: .normal)
@@ -53,9 +53,9 @@ class MyInfoViewController: DropDownViewController {
 
         if let gender = viewModel.gender {
             genderVC.collectionView.isUserInteractionEnabled = false
-            if gender == "남성" {
+            if gender == "male" {
                 genderVC.setSelectedItems(items: [0])
-            } else if gender == "여성" {
+            } else if gender == "female" {
                 genderVC.setSelectedItems(items: [1])
             }
         }
@@ -108,6 +108,19 @@ class MyInfoViewController: DropDownViewController {
     }
 
     @objc func clickCompleted(_ sender: UIButton) {
+        guard let nickname = nickNameVC.getText() else {
+            self.showToast(message: "닉네임을 입력하여주세요.")
+            return
+        }
+        if viewModel.job == 5 && viewModel.jobInfo == nil {
+            self.showToast(message: "기타 사항을 입력하여 주세요.")
+            return
+        }
+        if viewModel.year != nil && (viewModel.month == "" || viewModel.day == "") {
+            self.showToast(message: "생일을 전체 선택하여 주세요.")
+            return
+        }
+        viewModel.nickname = nickname
         updateUserInfo()
     }
 }

--- a/TellingMe/tellingMe/presentation/setting/myInfo/viewModel/MyInfoViewModel.swift
+++ b/TellingMe/tellingMe/presentation/setting/myInfo/viewModel/MyInfoViewModel.swift
@@ -23,7 +23,7 @@ class MyInfoViewModel {
     var yearArray: [String]?
     let monthArray = Array(1...12).map { String($0) }
     let dayArray = Array(1...31).map { String($0) }
-    
+
     init() {
         let today = Date()
         if let todayYear = Int(today.yearFormat()) {
@@ -45,9 +45,10 @@ class MyInfoViewModel {
         mbti = data.mbti
     }
 
-    func makeBirthData() -> String {
+    func makeBirthData() -> String? {
+        guard let year = self.year else { return nil}
         var resultString = ""
-        resultString += self.year ?? "1999"
+        resultString += year
         resultString += "-"
 
         if self.month.count == 1 {


### PR DESCRIPTION
- 답변 입력창 300자로 수정
- 답변 리스트 13월 삭제
- 답변 최소 길이 제한 설정
- 푸쉬->푸시 문구 수정
- 닉네임 변경 오류 수정
- 기타 직접 입력 제한 설정
- 성별 선택 오류 수정
- 회원 탈퇴 체크박스 수정
- 저장하기->탈퇴하기 문구 수정 67
feedback

### 📃 전달 사항
- 로그인 화면 서버 에러가 밀리초 단위로 들어오기 때문에 자동로그인 우선 후작업으로 미루기
아직 에러가 왜 나는진 모르겠지만 생각해봤을 때 웹에서 로그인하고 앱에서 저장된 토큰으로 들어가게 되면 당연히 다른 토큰이기 때문에 유효하지 않아 오류가 날 수 밖에없음. => 따로 이슈사항으로 작업하기

- 한글은 5글자인데 6/500 으로 뜨기도 함, 글자 수 세기 알고리즘 바꿀 수 있을지 확인해보기

- 감정선택 구분, 고민 수정,직접 입력 문구수정은 이해가 되지 않아 팀원들과 의논 후 다음 피드백에서 수정

✔ 진행사항
 - [ ] 감정 선택이 구분이 안됨
 - [x] 답변 입력창 500>300자로 수정 (프리미엄이 500, 기본은 300자)
 - [x] 답변 리스트에 13월의 존재
 - [x] 답변 최소 길이 제한 (4글자까지)
 - [x] ’푸쉬’ > ‘푸시’ 문구 수정, 선택 토글 넣기
 - [x] 닉네임` 변경 안됨
 - [ ] 고민 수정할 때 2가지를 한 번씩 골라야 선택 인정이 됨
 - [x] 기타 ’직접 입력’에 안적었는데도 수정 완료됨
 - [ ] 직접 입력’선택 안되어있을 때, 문구 ‘기타 선택 후 …’ > ‘직접 입력’ 으로 문구 수정
 - [x] 성별 남성/여성 선택이 안됨
 - [x] 회원 탈퇴 들어가면 이미 체크박스
 - [x] 회원 탈퇴 에서 ‘탈퇴하기’ 누르면 뜨는 모달에서 ‘저장하기’ > ‘탈퇴하기’ 로 수정


### 🔴 ETC
기타 사항을 적어주세요.
실제 개발 기간 : 3시간


### 💻 개발환경
macOS: Ventura 13.3.1
iOS: iphone 14 simulator


<hr>

closes: #67 
