### PR TITLE
 [#91] fix: kakao signup fix

### DIFF
--- a/TellingMe/tellingMe.xcodeproj/project.pbxproj
+++ b/TellingMe/tellingMe.xcodeproj/project.pbxproj
@@ -133,6 +133,7 @@
 		3ABB09F22A1A756600C6596B /* AnswerCompletedViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3ABB09F12A1A756600C6596B /* AnswerCompletedViewModel.swift */; };
 		3ABB84552A7ACD6F00540269 /* LikeAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3ABB84542A7ACD6F00540269 /* LikeAPI.swift */; };
 		3ABB84572A7ACD8100540269 /* Like.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3ABB84562A7ACD8100540269 /* Like.swift */; };
+		3ABB84592A7BD37300540269 /* WithdrawlDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3ABB84582A7BD37300540269 /* WithdrawlDTO.swift */; };
 		3AC204782A6BC1EB0005709A /* Communication.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 3AC204772A6BC1EB0005709A /* Communication.storyboard */; };
 		3AC2047B2A6BC5990005709A /* CommunityCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AC2047A2A6BC5990005709A /* CommunityCardView.swift */; };
 		3AC9D53829D58D8E006A2566 /* DropDownTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AC9D53729D58D8E006A2566 /* DropDownTableViewCell.swift */; };
@@ -312,6 +313,7 @@
 		3ABB09F12A1A756600C6596B /* AnswerCompletedViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnswerCompletedViewModel.swift; sourceTree = "<group>"; };
 		3ABB84542A7ACD6F00540269 /* LikeAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LikeAPI.swift; sourceTree = "<group>"; };
 		3ABB84562A7ACD8100540269 /* Like.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Like.swift; sourceTree = "<group>"; };
+		3ABB84582A7BD37300540269 /* WithdrawlDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WithdrawlDTO.swift; sourceTree = "<group>"; };
 		3AC204772A6BC1EB0005709A /* Communication.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = Communication.storyboard; sourceTree = "<group>"; };
 		3AC2047A2A6BC5990005709A /* CommunityCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommunityCardView.swift; sourceTree = "<group>"; };
 		3AC9D53729D58D8E006A2566 /* DropDownTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DropDownTableViewCell.swift; sourceTree = "<group>"; };
@@ -519,7 +521,7 @@
 				3A70A6422A272B15009D8D76 /* user */,
 				3A71213E2A03A84F00A02054 /* answer */,
 				3A00B74D29FBF1A400285CA8 /* question */,
-				3A5076EC29C82FE800C7A5E9 /* sign */,
+				3A5076EC29C82FE800C7A5E9 /* auth */,
 			);
 			path = data;
 			sourceTree = "<group>";
@@ -630,13 +632,13 @@
 			path = dropdown;
 			sourceTree = "<group>";
 		};
-		3A5076EC29C82FE800C7A5E9 /* sign */ = {
+		3A5076EC29C82FE800C7A5E9 /* auth */ = {
 			isa = PBXGroup;
 			children = (
 				3A00B74F29FBF1CF00285CA8 /* API */,
 				3A5076EF29C8333700C7A5E9 /* DTO */,
 			);
-			path = sign;
+			path = auth;
 			sourceTree = "<group>";
 		};
 		3A5076EF29C8333700C7A5E9 /* DTO */ = {
@@ -646,6 +648,7 @@
 				3A409B4129E148C700A05B22 /* SignUpDTO.swift */,
 				3AA1677029E8295C00B93850 /* CheckNicknameDTO.swift */,
 				3A38E3F029F55C7A00ABC201 /* JobInfoDTO.swift */,
+				3ABB84582A7BD37300540269 /* WithdrawlDTO.swift */,
 			);
 			path = DTO;
 			sourceTree = "<group>";
@@ -1475,6 +1478,7 @@
 				3A89B3C42A77ABA0002DFBCD /* CommunicationData.swift in Sources */,
 				3A00B75229FBF1FD00285CA8 /* QuestionDTO.swift in Sources */,
 				3A5076F329C8335900C7A5E9 /* OauthDTO.swift in Sources */,
+				3ABB84592A7BD37300540269 /* WithdrawlDTO.swift in Sources */,
 				3A3739B72A1243B700739543 /* ChipCollectionViewCell.swift in Sources */,
 				3A50EEFF29CCB2C400A27504 /* GetOptionViewController.swift in Sources */,
 				3A3739BB2A125F3B00739543 /* ChipJobViewController.swift in Sources */,
@@ -1713,7 +1717,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.3.13;
+				MARKETING_VERSION = 1.3.14;
 				PRODUCT_BUNDLE_IDENTIFIER = com.tellingUs.tellingMe;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -1743,7 +1747,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.3.13;
+				MARKETING_VERSION = 1.3.14;
 				PRODUCT_BUNDLE_IDENTIFIER = com.tellingUs.tellingMe;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;

--- a/TellingMe/tellingMe/data/auth/DTO/OauthDTO.swift
+++ b/TellingMe/tellingMe/data/auth/DTO/OauthDTO.swift
@@ -18,7 +18,7 @@ struct SignInResponse: Codable {
     let socialId: String
 }
 
-struct SignInErrorResponse: Error, Codable {
+struct SignInErrorResponse: Codable {
     let socialId: String
     let socialLoginType: String
 }

--- a/TellingMe/tellingMe/data/auth/DTO/WithdrawlDTO.swift
+++ b/TellingMe/tellingMe/data/auth/DTO/WithdrawlDTO.swift
@@ -6,3 +6,7 @@
 //
 
 import Foundation
+
+struct WithdrawalRequest: Codable {
+    var authorizationCode: String
+}

--- a/TellingMe/tellingMe/presentation/home/viewController/PushNotificationModalViewController.swift
+++ b/TellingMe/tellingMe/presentation/home/viewController/PushNotificationModalViewController.swift
@@ -9,29 +9,25 @@ import UIKit
 import Firebase
 
 class PushNotificationModalViewController: UIViewController {
-    
     override func viewDidLoad() {
         super.viewDidLoad()
     }
-    
+
     override func viewWillDisappear(_ animated: Bool) {
         self.view.backgroundColor = .clear
     }
-    
+
     func registerForNotification(completion: @escaping () -> Void) {
         let authOptions: UNAuthorizationOptions = [.alert, .badge, .sound]
         UNUserNotificationCenter.current().requestAuthorization(
             options: authOptions) { (granted, error) in
                 if granted {
                 }
-                
+
                 if let error = error {
                     DispatchQueue.main.async {
                         self.showToast(message: "푸시 알림을 등록할 수 없습니다.")
                     }
-                }
-                if let token = Messaging.messaging().fcmToken {
-                    KeychainManager.shared.save(token, key: Keys.firebaseToken.rawValue)
                 }
                 completion()
             }
@@ -39,6 +35,9 @@ class PushNotificationModalViewController: UIViewController {
     
     @IBAction func clickButton(_ sender: UIButton) {
         registerForNotification {
+            if let token = Messaging.messaging().fcmToken {
+                KeychainManager.shared.save(token, key: Keys.firebaseToken.rawValue)
+            }
             self.sendFirebaseToken()
         }
         self.sendNotification(tag: sender.tag)

--- a/TellingMe/tellingMe/presentation/login/repository/LoginRepository.swift
+++ b/TellingMe/tellingMe/presentation/login/repository/LoginRepository.swift
@@ -11,7 +11,6 @@ import KakaoSDKAuth
 import KakaoSDKUser
 import AuthenticationServices
 import Moya
-import Alamofire
 
 extension LoginViewController: ASAuthorizationControllerDelegate, ASAuthorizationControllerPresentationContextProviding {
     func callKakaoAPI() {
@@ -20,7 +19,11 @@ extension LoginViewController: ASAuthorizationControllerDelegate, ASAuthorizatio
                 if let error = error {
                     print("\(error)")
                 } else {
-                    self.login(type: "kakao", oauthToken: oauthToken?.accessToken ?? "")
+                    guard let oauthToken = oauthToken else {
+                        return
+                    }
+                    KeychainManager.shared.save(oauthToken.accessToken, key: Keys.idToken.rawValue)
+                    self.login(type: "kakao", oauthToken: oauthToken.accessToken)
                 }
             }
         } else {
@@ -28,12 +31,16 @@ extension LoginViewController: ASAuthorizationControllerDelegate, ASAuthorizatio
                 if let error = error {
                     print("\(error)")
                 } else {
-                    self.login(type: "kakao", oauthToken: oauthToken?.accessToken ?? "")
+                    guard let oauthToken = oauthToken else {
+                        return
+                    }
+                    KeychainManager.shared.save(oauthToken.accessToken, key: Keys.idToken.rawValue)
+                    self.login(type: "kakao", oauthToken: oauthToken.accessToken)
                 }
             }
         }
     }
-    
+
     func login(type: String, oauthToken: String) {
         LoginAPI.signIn(type: type, token: oauthToken) { result in
             switch result {

--- a/TellingMe/tellingMe/presentation/login/viewController/LoginViewController.swift
+++ b/TellingMe/tellingMe/presentation/login/viewController/LoginViewController.swift
@@ -40,12 +40,12 @@ class LoginViewController: UIViewController {
     func pushHome() {
         let storyboard = UIStoryboard(name: "MainTabBar", bundle: nil)
         guard let tabBarController = storyboard.instantiateViewController(withIdentifier: "mainTabBar") as? MainTabBarController else { return }
-        
+
         tabBarController.selectedIndex = 1
         guard let window = UIApplication.shared.windows.first else {
             return
         }
-        
+
         window.rootViewController = tabBarController
         window.makeKeyAndVisible()
     }

--- a/TellingMe/tellingMe/presentation/setting/main/viewController/WithdrawalViewController.swift
+++ b/TellingMe/tellingMe/presentation/setting/main/viewController/WithdrawalViewController.swift
@@ -6,15 +6,28 @@
 //
 
 import UIKit
+import AuthenticationServices
 
-class WithdrawalViewController: SettingViewController {
+class WithdrawalViewController: SettingViewController, ASAuthorizationControllerDelegate, ASAuthorizationControllerPresentationContextProviding {
     @IBOutlet weak var checkButton: UIButton!
     @IBOutlet weak var withdrawalButton: SecondaryTextButton!
+
     override func viewDidLoad() {
         super.viewDidLoad()
         checkButton.setImage(UIImage(systemName: "checkmark"), for: .selected)
         withdrawalButton.isEnabled = false
         headerView.setTitle(title: "회원 탈퇴")
+    }
+    
+    func callAppleAPI() {
+        let appleIDProvider = ASAuthorizationAppleIDProvider()
+        let request = appleIDProvider.createRequest()
+        request.requestedScopes = [.fullName, .email]
+
+        let authorizationController = ASAuthorizationController(authorizationRequests: [request])
+        authorizationController.delegate = self
+        authorizationController.presentationContextProvider = self
+        authorizationController.performRequests()
     }
 
     @IBAction func clickAgree(_ sender: UIButton) {
@@ -43,6 +56,11 @@ extension WithdrawalViewController: ModalActionDelegate {
     }
 
     func clickOk() {
-        withDrawalUser()
+        // 애플 로그인일 경우에는 authCode 받아서 진행
+        if KeychainManager.shared.load(key: Keys.socialLoginType.rawValue) == "apple" {
+            callAppleAPI()
+        } else {
+            withDrawalUser()
+        }
     }
 }


### PR DESCRIPTION
### 📃 전달 사항
글을 작성해야하는데 카카오 회원가입이 되지않아 회원가입 + 회원 탈퇴 수정 완료


### ✔ Done
- [x] 카카오 회원가입 로직 수정
- [x] 카카오 idToken값 저장
- [x] pushNotification 괜찮아요 누를시 계속 나오는 로직 수정
- [x] 회원 탈퇴 api 수정
- [x] authcode 받아오기 위한 apple 로그인 회원탈퇴 과정에 추가


### 🔴 ETC
실제 개발 기간 : 2시간


### 💻 개발환경
macOS: Ventura 13.3.1
iOS: iphone 14 simulator


<hr>

closes: #91
