### PR TITLE
나의 공간 & 모두의 공간에서 생기는 스크롤 효과를 수정하였습니다.

### DIFF
--- a/TellingMe/tellingMe.xcodeproj/project.pbxproj
+++ b/TellingMe/tellingMe.xcodeproj/project.pbxproj
@@ -1841,7 +1841,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.3.19;
+				MARKETING_VERSION = 1.0.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.tellingUs.tellingMe;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -1873,7 +1873,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.3.19;
+				MARKETING_VERSION = 1.0.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.tellingUs.tellingMe;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;

--- a/TellingMe/tellingMe/presentation/answerList/AnswerList.storyboard
+++ b/TellingMe/tellingMe/presentation/answerList/AnswerList.storyboard
@@ -243,8 +243,13 @@
             <point key="canvasLocation" x="1451" y="-308"/>
         </scene>
     </scenes>
+    <designables>
+        <designable name="XNg-Kd-8R0">
+            <size key="intrinsicContentSize" width="63.333333333333336" height="20.333333333333332"/>
+        </designable>
+    </designables>
     <resources>
-        <image name="MyAnswers" width="25" height="25"/>
+        <image name="MyAnswers" width="41" height="41"/>
         <image name="MyAnswers_selected" width="81" height="78"/>
         <image name="cardlist_selected" width="20" height="21"/>
         <image name="tablelist_selected" width="20" height="20"/>

--- a/TellingMe/tellingMe/presentation/answerList/view/CardListCollectionViewCell.swift
+++ b/TellingMe/tellingMe/presentation/answerList/view/CardListCollectionViewCell.swift
@@ -70,7 +70,7 @@ class CardListCollectionViewCell: UICollectionViewCell {
         attributedText.addAttribute(NSAttributedString.Key.font, value: font, range: NSMakeRange(0, attributedText.length))
 
         answerTextView.attributedText = attributedText
-        dateLabel.text = "\(data.date[0])년 \(data.date[1])월 \(data.date[2])일"
+        dateLabel.text = data.date.intArraytoDate2()
 
         contentView.backgroundColor = UIColor(named: "Side100")
         contentView.addSubview(containerView)
@@ -102,10 +102,10 @@ class CardListCollectionViewCell: UICollectionViewCell {
         answerTextView.trailingAnchor.constraint(equalTo: containerView.trailingAnchor).isActive = true
         answerTextView.heightAnchor.constraint(equalToConstant: 154).isActive = true
 
-        dateLabel.topAnchor.constraint(equalTo: contentView.bottomAnchor, constant: 72).isActive = true
+        dateLabel.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -72).isActive = true
         dateLabel.heightAnchor.constraint(equalToConstant: 14).isActive = true
         dateLabel.trailingAnchor.constraint(equalTo: containerView.trailingAnchor).isActive = true
-        
+
         contentView.layer.cornerRadius = 24
     }
 }

--- a/TellingMe/tellingMe/presentation/answerList/viewController/CardListCollectionViewController.swift
+++ b/TellingMe/tellingMe/presentation/answerList/viewController/CardListCollectionViewController.swift
@@ -10,11 +10,13 @@ import UIKit
 class CardListCollectionViewController: UICollectionViewController, UICollectionViewDelegateFlowLayout {
     static let id = "cardListCollectionViewController"
     var answerList: [AnswerListResponse] = []
+    var row = 0
     let leadingPadding: CGFloat = 36
     let itemSpacing: CGFloat = 21
 
     override func viewDidLoad() {
         super.viewDidLoad()
+        collectionView.decelerationRate = .fast
     }
 
     override func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
@@ -66,27 +68,32 @@ class CardListCollectionViewController: UICollectionViewController, UICollection
       }
 
     override func scrollViewWillEndDragging(_ scrollView: UIScrollView, withVelocity velocity: CGPoint, targetContentOffset: UnsafeMutablePointer<CGPoint>) {
+        
         let itemWidth = collectionView.bounds.width - (leadingPadding * 2)
 
-        let collectionViewCenterX = targetContentOffset.pointee.x + collectionView.bounds.width / 2
+        let cellWidthIncludingSpacing = targetContentOffset.pointee.x + collectionView.bounds.width / 2
 
-        // 스크롤 방향을 확인하여 페이지를 결정합니다.
-        let targetPage: CGFloat
+        // 이동한 x좌표 값과 item의 크기를 비교 후 페이징 값 설정
+        let estimatedIndex = cellWidthIncludingSpacing / itemWidth
+        // 스크롤 방향 체크
+        // item 절반 사이즈 만큼 스크롤로 판단하여 올림, 내림 처리
         if velocity.x > 0 {
-            targetPage = ceil(collectionViewCenterX / itemWidth)
+            if row < answerList.count - 1 {
+                row += 1
+            }
         } else if velocity.x < 0 {
-            targetPage = floor(collectionViewCenterX / itemWidth)
+            if row > 0 {
+                row -= 1
+            }
         } else {
-            targetPage = round(collectionViewCenterX / itemWidth)
         }
-        if targetPage == 0 {
-            targetContentOffset.pointee = CGPoint(x: 0, y: targetContentOffset.pointee.y)
-        } else if Int(targetPage) == answerList.count - 1 {
-            targetContentOffset.pointee = CGPoint(x: CGFloat(answerList.count) * collectionView.bounds.width, y: targetContentOffset.pointee.y)
+
+        if row == 0 {
+            targetContentOffset.pointee = CGPoint(x: 0, y: 0)
+        } else if row == answerList.count - 1 {
+            targetContentOffset.pointee = CGPoint(x: CGFloat(answerList.count - 1) * collectionView.bounds.width, y: 0)
         } else {
-            let offsetX = targetPage*(itemWidth + itemSpacing)
-            // targetContentOffset을 변경하여 중앙 정렬을 구현합니다.
-            targetContentOffset.pointee = CGPoint(x: offsetX, y: targetContentOffset.pointee.y)
+            targetContentOffset.pointee = CGPoint(x: row * Int((itemWidth + itemSpacing)), y: 0)
         }
     }
 }

--- a/TellingMe/tellingMe/presentation/communication/viewControllers/Communication.storyboard
+++ b/TellingMe/tellingMe/presentation/communication/viewControllers/Communication.storyboard
@@ -162,6 +162,7 @@
                                             </imageView>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="이전 질문" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="GbA-rv-ehm" customClass="CaptionLabelBold" customModule="tellingMe" customModuleProvider="target">
                                                 <rect key="frame" x="28" y="5.6666666666666288" width="64" height="21"/>
+                                                <color key="backgroundColor" name="Side100"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <color key="textColor" name="Gray6"/>
                                                 <nil key="highlightedColor"/>
@@ -190,6 +191,7 @@
                                             </imageView>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="다음 질문" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="o8A-Z2-ykn" customClass="CaptionLabelBold" customModule="tellingMe" customModuleProvider="target">
                                                 <rect key="frame" x="-17" y="5.6666666666666288" width="64" height="21"/>
+                                                <color key="backgroundColor" name="Side100"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <color key="textColor" name="Gray6"/>
                                                 <nil key="highlightedColor"/>

--- a/TellingMe/tellingMe/presentation/communication/viewControllers/CommunicationListViewController.swift
+++ b/TellingMe/tellingMe/presentation/communication/viewControllers/CommunicationListViewController.swift
@@ -32,9 +32,11 @@ class CommunicationListViewController: UIViewController {
         let layout = UICollectionViewFlowLayout()
         layout.sectionHeadersPinToVisibleBounds = true
         let view = UICollectionView(frame: .zero, collectionViewLayout: layout)
+        view.alwaysBounceVertical = false
         view.showsVerticalScrollIndicator = true
         view.backgroundColor = UIColor(named: "Side100")
         view.translatesAutoresizingMaskIntoConstraints = false
+//        view.contentInset = UIEdgeInsets(top: 0, left: 0, bottom: 100, right: 0)
         return view
     }()
 
@@ -177,39 +179,54 @@ extension CommunicationListViewController: UICollectionViewDelegate, UICollectio
         return UICollectionReusableView()
     }
     
+    func scrollViewDidScrollToTop(_ scrollView: UIScrollView) {
+        self.viewModel.isTop = true
+        self.questionViewOriginalHeightConstraint.isActive = false
+        self.questionViewOriginalHeightConstraint = self.questionView.heightAnchor.constraint(equalToConstant: 120)
+        self.questionViewOriginalHeightConstraint.isActive = true
+
+        UIView.animate(withDuration: 0.3, animations: {
+            self.view.layoutIfNeeded()
+        })
+    }
+
     func scrollViewDidScroll(_ scrollView: UIScrollView) {
         if viewModel.isFetchingData {
             return // 이미 데이터를 가져오는 중이라면 무시
         }
-
+        
         let contentOffset = scrollView.contentOffset
-
-        if contentOffset.y < 160 {
+        if contentOffset.y <= 10 {
             // 스크롤을 위로 올릴 때의 작업을 여기에 수행합니다.
             if !self.viewModel.isTop {
                 self.viewModel.isTop = true
                 self.questionViewOriginalHeightConstraint.isActive = false
                 self.questionViewOriginalHeightConstraint = self.questionView.heightAnchor.constraint(equalToConstant: 120)
                 self.questionViewOriginalHeightConstraint.isActive = true
-            } else {
-                return
+
+                UIView.animate(withDuration: 0.3, animations: {
+                    self.view.layoutIfNeeded()
+                })
             }
-        } else {
-            // 스크롤을 아래로 내릴 때의 작업을 여기에 수행합니다.
+        }
+
+        if isNearBottomEdge(scrollView: scrollView) && !self.viewModel.isTop {
+            viewModel.getCommunicationList()
+            return
+        }
+
+        if contentOffset.y > 120 {
             if self.viewModel.isTop {
                 self.viewModel.isTop = false
                 self.questionViewOriginalHeightConstraint.isActive = false
                 self.questionViewOriginalHeightConstraint = self.questionView.heightAnchor.constraint(equalToConstant: 0)
                 self.questionViewOriginalHeightConstraint.isActive = true
-            } else {
-                return
+
+                UIView.animate(withDuration: 0.3, animations: {
+                    self.view.layoutIfNeeded()
+                })
             }
         }
-
-         // 레이아웃을 업데이트하고 재계산합니다.
-        UIView.animate(withDuration: 0.3, animations: {
-            self.view.layoutIfNeeded()
-        })
     }
 }
 

--- a/TellingMe/tellingMe/presentation/communication/viewModel/CommunicationListViewModel.swift
+++ b/TellingMe/tellingMe/presentation/communication/viewModel/CommunicationListViewModel.swift
@@ -104,6 +104,7 @@ class CommunicationListViewModel {
         if isLast {
             return
         }
+        CommunicationData.shared.currentPage += 1
         CommunicationAPI.getCommunicationList(date: date, page: CommunicationData.shared.currentPage, size: size, sort: CommunicationData.shared.currentSortValue)
             .subscribe(onNext: { [weak self] response in
                 CommunicationData.shared.setCommunicatonList(index: self?.index ?? 0, contentList: response.content)


### PR DESCRIPTION
### 📃 전달 사항
스크롤 관련해서 생기는 문제들을 수정하였습니다.
기존 나의 공간 스크롤은 페이징이아니라 사용자가 원하는만큼 스크롤이 가능하되, 멈추면 중앙에 딱 맞아 떨어지게 해뒀는데
이 멈출 때 까지 기다리지않고 다시 스크롤하면 어색하고 버그처럼 보이는 현상이 있어서 페이징 처리하기로 했습니다.
모두의 공간 스크롤은 위에 질문 있는 view가 접히면서 스크롤 크기에 영향이 가 뷰의 버그가 생기는 것으로 생각되어 스크롤이 top과 bottom에 있을 때는 접거나 펴지는 효과가 없도록 설정하였습니다.
13mini & 11 에서 문제 없는거 확인하였습니다. (답변 3,4개일 때만 생기는 문제입니다)



### ✔ 진행사항
- [x] 나의 공간 스크롤 페이징처리하기
- [x] 모두의 공간 스크롤 헤더 픽스하기


### 🔴 ETC
기타 사항을 적어주세요.
실제 개발 기간 : 4시간


### 💻 개발환경
macOS: Ventura 13.3.1
iOS: iphone 14 pro simulator


<hr>

closes: #106 
