### PR TITLE
홈 뷰의 새로고침과 탭바의 색상이 깨지는 버그를 Fix 했습니다.

### DIFF
--- a/TellingMe/tellingMe/presentation/home/repository/HomeRepository.swift
+++ b/TellingMe/tellingMe/presentation/home/repository/HomeRepository.swift
@@ -9,7 +9,9 @@ import Foundation
 
 extension HomeViewController {
     func getQuestion() {
-        guard let date = viewModel.questionDate else {
+        // 함수가 호출될 때마다, 새롭게 Date 인스턴스를 만듭니다.
+        let newDateString = Date().getQuestionDate()
+        guard let date = newDateString else {
             self.showToast(message: "날짜를 불러올 수 없습니다.")
             return
         }

--- a/TellingMe/tellingMe/presentation/home/repository/HomeRepository.swift
+++ b/TellingMe/tellingMe/presentation/home/repository/HomeRepository.swift
@@ -34,7 +34,8 @@ extension HomeViewController {
     }
 
     func getAnswer() {
-        guard let date = viewModel.questionDate else {
+        let newDateString = Date().getQuestionDate()
+        guard let date = newDateString else {
             self.showToast(message: "날짜를 불러올 수 없습니다.")
             return
         }
@@ -56,7 +57,8 @@ extension HomeViewController {
     }
 
     func getAnswerRecord() {
-        guard let date = viewModel.questionDate else {
+        let newDateString = Date().getQuestionDate()
+        guard let date = newDateString else {
             self.showToast(message: "날짜를 불러올 수 없습니다.")
             return
         }

--- a/TellingMe/tellingMe/presentation/tab/MainTabBarController.swift
+++ b/TellingMe/tellingMe/presentation/tab/MainTabBarController.swift
@@ -20,10 +20,6 @@ class MainTabBarController: UITabBarController {
         // Storyboard 에서만 세팅되어 있는 걸 여기서 한번 더 ensure 하기 위해 선언
         tabBar.backgroundColor = .Side100
     }
-    
-//    override func viewWillAppear(_ animated: Bool) {
-//        super.viewWillAppear(animated)
-//    }
 
     func showPushNotification() {
         let storyboard = UIStoryboard(name: "Home", bundle: nil)

--- a/TellingMe/tellingMe/presentation/tab/MainTabBarController.swift
+++ b/TellingMe/tellingMe/presentation/tab/MainTabBarController.swift
@@ -10,11 +10,6 @@ import UIKit
 class MainTabBarController: UITabBarController {
     let shadowView = UIView()
 
-//    override func viewWillAppear(_ animated: Bool) {
-//        super.viewWillAppear(animated)
-//        self.tabBar.isHidden = false
-//    }
-
     override func viewDidLoad() {
         tabBar.frame = CGRect(x: 0, y: view.frame.height - 88, width: view.frame.width, height: 88)
         super.viewDidLoad()
@@ -22,7 +17,13 @@ class MainTabBarController: UITabBarController {
         self.delegate = self
         tabBar.layer.cornerRadius = 32
         tabBar.layer.maskedCorners = [.layerMinXMinYCorner, .layerMaxXMinYCorner]
+        // Storyboard 에서만 세팅되어 있는 걸 여기서 한번 더 ensure 하기 위해 선언
+        tabBar.backgroundColor = .Side100
     }
+    
+//    override func viewWillAppear(_ animated: Bool) {
+//        super.viewWillAppear(animated)
+//    }
 
     func showPushNotification() {
         let storyboard = UIStoryboard(name: "Home", bundle: nil)


### PR DESCRIPTION
### 📃 전달 사항
1. 새로고침을 설정했습니다. 자세한 원인은 이슈를 참고해주세요.
   - #115 
2. 색상이 깨지는 버그는 코드상 문제가 없는데 생기는 버그라, 스토리 보드에서만이 아닌 코드로도 background 색을 지정했습니다.


### ✔ 진행사항
- [x] 새로고침
- [x] 탭바 색상


### 🔴 ETC
기타 사항을 적어주세요.
실제 개발 기간 : 1시간


### 💻 개발환경
macOS: Ventura 13.5
iOS: iphone 14 pro simulator


<hr>

closes: #115 
