### PR TITLE
[#117] fix: fix the pushNotification error with null

### DIFF
--- a/TellingMe/tellingMe.xcodeproj/project.pbxproj
+++ b/TellingMe/tellingMe.xcodeproj/project.pbxproj
@@ -128,6 +128,7 @@
 		3AB213222A892F3F0035EA56 /* CommunicationNoneViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AB213212A892F3F0035EA56 /* CommunicationNoneViewCell.swift */; };
 		3AB213252A8939640035EA56 /* Alert.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 3AB213242A8939640035EA56 /* Alert.storyboard */; };
 		3AB213272A8939830035EA56 /* AlertViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AB213262A8939830035EA56 /* AlertViewController.swift */; };
+		3AB25D9C2A9F642B004C2872 /* PushNotificationInfoDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AB25D9B2A9F642B004C2872 /* PushNotificationInfoDTO.swift */; };
 		3AB795782A6E960F009961CF /* CommunityViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AB795772A6E960F009961CF /* CommunityViewController.swift */; };
 		3AB7957D2A6E98AD009961CF /* CommunicationAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AB7957C2A6E98AD009961CF /* CommunicationAPI.swift */; };
 		3AB7957F2A6E9D61009961CF /* QuestionList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AB7957E2A6E9D61009961CF /* QuestionList.swift */; };
@@ -364,6 +365,7 @@
 		3AB213212A892F3F0035EA56 /* CommunicationNoneViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommunicationNoneViewCell.swift; sourceTree = "<group>"; };
 		3AB213242A8939640035EA56 /* Alert.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = Alert.storyboard; sourceTree = "<group>"; };
 		3AB213262A8939830035EA56 /* AlertViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertViewController.swift; sourceTree = "<group>"; };
+		3AB25D9B2A9F642B004C2872 /* PushNotificationInfoDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushNotificationInfoDTO.swift; sourceTree = "<group>"; };
 		3AB795772A6E960F009961CF /* CommunityViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommunityViewController.swift; sourceTree = "<group>"; };
 		3AB7957C2A6E98AD009961CF /* CommunicationAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommunicationAPI.swift; sourceTree = "<group>"; };
 		3AB7957E2A6E9D61009961CF /* QuestionList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuestionList.swift; sourceTree = "<group>"; };
@@ -817,6 +819,7 @@
 				3A70A6472A272C58009D8D76 /* UpdateUserInfoDTO.swift */,
 				3A70A6492A272CD2009D8D76 /* NotificationDTO.swift */,
 				3A3914912A3DA6D5005A5417 /* FirebaseTokenDTO.swift */,
+				3AB25D9B2A9F642B004C2872 /* PushNotificationInfoDTO.swift */,
 			);
 			path = dto;
 			sourceTree = "<group>";
@@ -1815,6 +1818,7 @@
 				3AEED26329C99F1500D02F3F /* HeadlineLabel.swift in Sources */,
 				3AB7957D2A6E98AD009961CF /* CommunicationAPI.swift in Sources */,
 				3A320F262A6F6EE90098E8C9 /* QuestionView.swift in Sources */,
+				3AB25D9C2A9F642B004C2872 /* PushNotificationInfoDTO.swift in Sources */,
 				3AA289CB29B8506F0030057E /* AppDelegate.swift in Sources */,
 				3AA289CD29B8506F0030057E /* SceneDelegate.swift in Sources */,
 				3A50EEFD29CCB29300A27504 /* GetBirthdayViewController.swift in Sources */,

--- a/TellingMe/tellingMe/data/user/api/UserAPI.swift
+++ b/TellingMe/tellingMe/data/user/api/UserAPI.swift
@@ -12,6 +12,8 @@ import RxSwift
 enum UserAPITarget {
     case getUserInfo
     case updateUserInfo(UpdateUserInfoRequest)
+    case getPushNotificationInfo
+    case postPushNotificationInfo(PushNotificationInfoRequest)
     case getisAllowedNotification
     case postisAllowedNotification(AllowedNotificationRequest)
     case postFirebaseToken(FirebaseTokenRequest)
@@ -25,6 +27,8 @@ extension UserAPITarget: TargetType {
         case .postFirebaseToken(let body):
             return .requestJSONEncodable(body)
         case .postisAllowedNotification(let body):
+            return .requestJSONEncodable(body)
+        case .postPushNotificationInfo(let body):
             return .requestJSONEncodable(body)
         default:
             return .requestPlain
@@ -43,6 +47,10 @@ extension UserAPITarget: TargetType {
             return "api/user/update/notification"
         case .postFirebaseToken:
             return "api/user/update/pushToken"
+        case .getPushNotificationInfo:
+            return "api/user/push"
+        case .postPushNotificationInfo:
+            return "api/user/update/push"
         }
     }
 
@@ -50,7 +58,7 @@ extension UserAPITarget: TargetType {
         switch self {
         case .updateUserInfo:
             return .patch
-        case .postisAllowedNotification, .postFirebaseToken:
+        case .postisAllowedNotification, .postFirebaseToken, .postPushNotificationInfo:
             return .post
         default:
             return .get
@@ -133,6 +141,24 @@ struct UserAPI: Networkable {
         do {
             let provider =  try makeAuthorizedProvider()
             return provider.request(target: .postFirebaseToken(request))
+        } catch {
+            return Observable.error(APIError.tokenNotFound)
+        }
+    }
+    
+    static func getPushNotificationInfo() -> Observable<PushNotificationInfoResponse> {
+        do {
+            let provider = try makeAuthorizedProvider()
+            return provider.request(target: .getPushNotificationInfo)
+        } catch {
+            return Observable.error(APIError.tokenNotFound)
+        }
+    }
+    
+    static func postPushNotificationInfo(request: PushNotificationInfoRequest) -> Observable<PushNotificationInfoResponse> {
+        do {
+            let provider = try makeAuthorizedProvider()
+            return provider.request(target: .postPushNotificationInfo(request))
         } catch {
             return Observable.error(APIError.tokenNotFound)
         }

--- a/TellingMe/tellingMe/data/user/dto/FirebaseTokenDTO.swift
+++ b/TellingMe/tellingMe/data/user/dto/FirebaseTokenDTO.swift
@@ -8,5 +8,5 @@
 import Foundation
 
 struct FirebaseTokenRequest: Codable {
-    let pushToken: String?
+    let pushToken: String
 }

--- a/TellingMe/tellingMe/data/user/dto/PushNotificationInfoDTO.swift
+++ b/TellingMe/tellingMe/data/user/dto/PushNotificationInfoDTO.swift
@@ -1,0 +1,18 @@
+//
+//  PushNotificationInfoDTO.swift
+//  tellingMe
+//
+//  Created by 마경미 on 30.08.23.
+//
+
+import Foundation
+
+struct PushNotificationInfoRequest: Codable {
+    let allowNotification: Bool
+    let pushToken: String
+}
+
+struct PushNotificationInfoResponse: Codable {
+    let allowNotification: Bool?
+    let pushToken: String?
+}

--- a/TellingMe/tellingMe/presentation/home/viewController/HomeViewController.swift
+++ b/TellingMe/tellingMe/presentation/home/viewController/HomeViewController.swift
@@ -6,6 +6,8 @@
 //
 
 import UIKit
+import RxSwift
+import RxCocoa
 
 class HomeViewController: UIViewController {
     let viewModel = HomeViewModel()
@@ -22,11 +24,14 @@ class HomeViewController: UIViewController {
     @IBOutlet var shadowViews: [UIImageView]!
     @IBOutlet weak var rotateAnimationView: UIImageView!
     @IBOutlet weak var answerCompletedLabel: CaptionLabelRegular!
+    
+    let disposeBag = DisposeBag()
 
     override func viewDidLoad() {
         super.viewDidLoad()
         setView()
         checkNofitication()
+        bindViewModel()
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -157,5 +162,14 @@ extension HomeViewController: HeaderViewDelegate {
                 print("❎ New Notices doesn't exist.")
             }
         }
+    }
+    
+    func bindViewModel() {
+        viewModel.pushNotificationInfoSubject
+            .skip(1)
+            .bind(onNext: { [weak self] _ in
+                self?.showPushNotification()
+            })
+            .disposed(by: disposeBag)
     }
 }

--- a/TellingMe/tellingMe/presentation/home/viewController/PushNotificationModalViewController.swift
+++ b/TellingMe/tellingMe/presentation/home/viewController/PushNotificationModalViewController.swift
@@ -43,21 +43,25 @@ class PushNotificationModalViewController: UIViewController {
 
     func bindViewModel() {
         okButton.rx.tap
-            .subscribe(onNext: { [weak self] _ in
+            .bind(onNext: { [weak self] _ in
                 self?.clickButton(true)
             }).disposed(by: disposeBag)
         cancelButton.rx.tap
-            .subscribe(onNext: { [weak self] _ in
+            .bind(onNext: { [weak self] _ in
                 self?.clickButton(false)
+            }).disposed(by: disposeBag)
+        viewModel.successSujbect
+            .bind(onNext: { [weak self] _ in
+                self?.dismiss(animated: true)
             }).disposed(by: disposeBag)
     }
 
     func clickButton(_ agree: Bool) {
         registerForNotification()
         if let token = Messaging.messaging().fcmToken {
-            self.viewModel.postFirebaseToken(token: token)
+            self.viewModel.postPushNotification(isAgree: agree, token: token)
+        } else {
+            self.showToast(message: "토큰을 찾을 수 없습니다.")
         }
-        self.viewModel.postNotifiactionStatus(agree)
-        self.dismiss(animated: true)
     }
 }

--- a/TellingMe/tellingMe/presentation/home/viewModel/HomeViewModel.swift
+++ b/TellingMe/tellingMe/presentation/home/viewModel/HomeViewModel.swift
@@ -16,6 +16,10 @@ class HomeViewModel {
     let questionDate = Date().getQuestionDate()
     var isAnswerCompleted = false
     
+    let pushNotificationInfoSubject = BehaviorSubject<PushNotificationInfoResponse?>(value: nil)
+    let showToastSubject = BehaviorSubject<String>(value: "")
+    let disposeBag = DisposeBag()
+    
     func getNewNotices(completion: @escaping (Bool) -> Void) {
         AlarmNotificationAPI.getAlarmSummary { response in
             switch response {
@@ -26,5 +30,29 @@ class HomeViewModel {
                 print(error)
             }
         }
+    }
+    
+    init() {
+        getPushNotificationInfo()
+    }
+    
+    // MARK: 이미 데이터베이스에 정보를 못 넣은 사람들을 위한 메서드로 nil일 경우에 onNext
+    func getPushNotificationInfo() {
+        UserAPI.getPushNotificationInfo()
+            .subscribe(onNext: { [weak self] response in
+                if let status = response.allowNotification,
+                   let token = response.pushToken {
+                    print("\(status), \(token)")
+                } else {
+                    self?.pushNotificationInfoSubject.onNext(response)
+                }
+            }, onError: { [weak self] error in
+                switch error {
+                case APIError.errorData(let errorData):
+                    self?.showToastSubject.onNext(errorData.message)
+                default:
+                    self?.showToastSubject.onNext("푸시 알림 정보를 받아오는데 실패하였습니다.")
+                }
+            }).disposed(by: disposeBag)
     }
 }

--- a/TellingMe/tellingMe/presentation/home/viewModel/PushNotificationViewModel.swift
+++ b/TellingMe/tellingMe/presentation/home/viewModel/PushNotificationViewModel.swift
@@ -7,39 +7,57 @@
 
 import Foundation
 import RxSwift
+import RxCocoa
 
 class PushNotifiactionViewModel {
+    let successSujbect = BehaviorSubject<PushNotificationInfoResponse>(value: .init(allowNotification: nil, pushToken: nil))
     let showToastSubject = PublishSubject<String>()
     let disposeBag = DisposeBag()
 
-    func postNotifiactionStatus(_ isAgree: Bool) {
-        let request = AllowedNotificationRequest(notificationStatus: isAgree)
-        UserAPI.postNotification(request: request)
-            .subscribe(onNext: { [weak self] _ in
-            }, onError: { [weak self] error in
-                if case APIError.errorData(let errorData) = error {
-                    self?.showToastSubject.onNext(errorData.message)
-                } else if case APIError.tokenNotFound = error {
-                    self?.showToastSubject.onNext("login으로 push할게요")
-                } else {
-                    self?.showToastSubject.onNext("An error occurred")
-                }
-            }).disposed(by: disposeBag)
-    }
-
-    func postFirebaseToken(token: String) {
+//    func postNotifiactionStatus(_ isAgree: Bool) {
+//        let request = AllowedNotificationRequest(notificationStatus: isAgree)
+//        UserAPI.postNotification(request: request)
+//            .subscribe(onNext: { [weak self] _ in
+//            }, onError: { [weak self] error in
+//                if case APIError.errorData(let errorData) = error {
+//                    self?.showToastSubject.onNext(errorData.message)
+//                } else if case APIError.tokenNotFound = error {
+//                    self?.showToastSubject.onNext("login으로 push할게요")
+//                } else {
+//                    self?.showToastSubject.onNext("An error occurred")
+//                }
+//            }).disposed(by: disposeBag)
+//    }
+//
+//    func postFirebaseToken(token: String) {
+//        KeychainManager.shared.save(token, key: Keys.firebaseToken.rawValue)
+//        guard let token = KeychainManager.shared.load(key: Keys.firebaseToken.rawValue) else {
+//            return
+//        }
+//        let request = FirebaseTokenRequest(pushToken: token)
+//        UserAPI.postFirebaseToken(request: request)
+//            .subscribe(onNext: { _ in
+//            }, onError: { [weak self] error in
+//                if case APIError.tokenNotFound = error {
+//                    print("should move to login")
+//                } else {
+//                    print(error)
+//                }
+//            }).disposed(by: disposeBag)
+//    }
+    
+    func postPushNotification(isAgree: Bool, token: String) {
         KeychainManager.shared.save(token, key: Keys.firebaseToken.rawValue)
-        guard let token = KeychainManager.shared.load(key: Keys.firebaseToken.rawValue) else {
-            return
-        }
-        let request = FirebaseTokenRequest(pushToken: token)
-        UserAPI.postFirebaseToken(request: request)
-            .subscribe(onNext: { _ in
+        let request = PushNotificationInfoRequest(allowNotification: isAgree, pushToken: token)
+        UserAPI.postPushNotificationInfo(request: request)
+            .subscribe(onNext: { [weak self] response in
+                self?.successSujbect.onNext(response)
             }, onError: { [weak self] error in
-                if case APIError.tokenNotFound = error {
-                    print("should move to login")
-                } else {
-                    print(error)
+                switch error {
+                case APIError.errorData(let errorData):
+                    self?.showToastSubject.onNext(errorData.message)
+                default:
+                    self?.showToastSubject.onNext("푸시 알림을 등록할 수 없습니다.")
                 }
             }).disposed(by: disposeBag)
     }

--- a/TellingMe/tellingMe/presentation/signUp/SignUp.storyboard
+++ b/TellingMe/tellingMe/presentation/signUp/SignUp.storyboard
@@ -59,7 +59,7 @@
                                     <constraint firstAttribute="bottom" secondItem="Gz5-lH-4QR" secondAttribute="bottom" constant="14" id="prU-u4-XEP"/>
                                 </constraints>
                             </view>
-                            <progressView opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="750" progress="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="4SJ-68-6xM" customClass="GradientProgressBar" customModule="GradientProgress">
+                            <progressView opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="750" progress="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="4SJ-68-6xM" customClass="GradientProgressBar" customModule="tellingMe" customModuleProvider="target">
                                 <rect key="frame" x="25" y="116" width="325" height="5"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="5" id="wQs-nV-aOs"/>


### PR DESCRIPTION
### 📃 전달 사항
회원가입 후에 홈에 오면 생기는 알림 동의 모달창에 관한 오류사항입니다.

저희 쪽에서는 푸시 notification status와 push token을 서버로 request하는 로그가 찍힙니다.
response오는 로그도 찍힙니다.
디비에는 저장이 되지 않습니다.
서버쪽에 push token만 api 기록이 남아있습니다.
따라서 서버팀과 합의 후 status와 token을 한꺼번에 보내는 api를 새로 구현하기로 하였습니다.
이 기능은 3차 때 뺄 예정입니다!
서버팀과 테스트 완료 했습니다 :)


### ✔ 진행사항
- [ ]  pushnotification api 추가하기
- [ ] 회원가입 이후 pushnotification logic 수정하기
- [ ]  이미 데이터가 잘 못 들어간 사람들에게 알림창 띄우기 ( 홈에서 getAPI하도록 하겠습니다 )


### 🔴 ETC
기타 사항을 적어주세요.
실제 개발 기간 :  2시간


### 💻 개발환경
macOS: Ventura 13.3.1
iOS: iphone 14 pro simulator


<hr>

closes: #117 
