### PR TITLE
홈-알림 UI Bug 와 탭 색상이 깨지는 것을 고칩니다.

### DIFF
--- a/TellingMe/tellingMe/app/SceneDelegate.swift
+++ b/TellingMe/tellingMe/app/SceneDelegate.swift
@@ -44,6 +44,9 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     func sceneDidBecomeActive(_ scene: UIScene) {
         // Called when the scene has moved from an inactive state to an active state.
         // Use this method to restart any tasks that were paused (or not yet started) when the scene was inactive.
+        print("Re-Called Check")
+        NotificationCenter.default.post(name: Notification.Name("RefreshHomeView"), object: nil)
+        NotificationCenter.default.post(name: Notification.Name("RefreshAnimation"), object: nil)
     }
 
     func sceneWillResignActive(_ scene: UIScene) {

--- a/TellingMe/tellingMe/data/alarm/dto/AlarmDTO.swift
+++ b/TellingMe/tellingMe/data/alarm/dto/AlarmDTO.swift
@@ -29,8 +29,8 @@ struct AlarmFetchDataWithDateRequest: Codable {
  */
 struct AlarmNotificationResponse: Codable {
     let noticeId: Int
-    let title: String?
-    let content: String
+    let title: String
+    let content: String?
     let isRead: Bool
     let createdAt: [Int]
     let link: String?

--- a/TellingMe/tellingMe/presentation/alarm/viewControllers/AlarmViewController.swift
+++ b/TellingMe/tellingMe/presentation/alarm/viewControllers/AlarmViewController.swift
@@ -11,6 +11,10 @@ import RxCocoa
 import RxMoya
 import RxSwift
 
+protocol AlarmReadAllTappedProtocol: AnyObject {
+    func readAllTapped()
+}
+
 final class AlarmViewController: UIViewController {
 
     private let navigationBarView = AlarmNavigationBarView()
@@ -20,6 +24,8 @@ final class AlarmViewController: UIViewController {
     private var disposeBag = DisposeBag()
     private let viewModel = AlarmNoticeViewModel()
     private lazy var isNoticeAllRead: BehaviorRelay<Bool> = viewModel.outputs.isAlarmAllRead
+    
+    weak var delegate: AlarmReadAllTappedProtocol?
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -56,6 +62,7 @@ extension AlarmViewController {
                 self?.viewModel.inputs.readAllNotice()
                 self?.alarmSectionView.isAllNoticeRead(true)
                 self?.alarmNoticeTableView.reloadData()
+                self?.delegate?.readAllTapped()
             }
             .disposed(by: disposeBag)
         

--- a/TellingMe/tellingMe/presentation/alarm/viewModel/AlarmViewModel.swift
+++ b/TellingMe/tellingMe/presentation/alarm/viewModel/AlarmViewModel.swift
@@ -76,8 +76,6 @@ final class AlarmNoticeViewModel: AlarmNoticeViewModelInputs, AlarmNoticeViewMod
                 }
             })
             .disposed(by: disposeBag)
-        
-        fetchNoticeData()
     }
     
     func readNotice(idOf id: Int) {
@@ -116,7 +114,7 @@ final class AlarmNoticeViewModel: AlarmNoticeViewModelInputs, AlarmNoticeViewMod
 
 extension AlarmNoticeViewModel {
     
-    private func fetchNoticeData() {
+    func fetchNoticeData() {
         AlarmNotificationAPI.getAllAlarmNotice()
             .subscribe(onNext: { [weak self] response in
                 self?.alarmNotices.onNext(response)

--- a/TellingMe/tellingMe/presentation/alarm/views/AlarmTableViewCell.swift
+++ b/TellingMe/tellingMe/presentation/alarm/views/AlarmTableViewCell.swift
@@ -12,7 +12,7 @@ import Then
 
 final class AlarmTableViewCell: UITableViewCell {
     
-    private var alarmNoticeInformation: AlarmNotificationResponse = .init(noticeId: 0, title: nil, content: "", isRead: false, createdAt: [], link: nil, isInternal: false, answerId: nil, date: nil)
+    private var alarmNoticeInformation: AlarmNotificationResponse = .init(noticeId: 0, title: "", content: nil, isRead: false, createdAt: [], link: nil, isInternal: false, answerId: nil, date: nil)
     
     private let titleLabel = UILabel()
     private let subTitleLabel = UILabel()
@@ -83,7 +83,7 @@ extension AlarmTableViewCell {
     }
     
     private func resetProperties() {
-        self.alarmNoticeInformation = .init(noticeId: 0, title: nil, content: "", isRead: false, createdAt: [], link: nil, isInternal: false, answerId: nil, date: nil)
+        self.alarmNoticeInformation = .init(noticeId: 0, title: "", content: nil, isRead: false, createdAt: [], link: nil, isInternal: false, answerId: nil, date: nil)
         self.titleLabel.text = nil
         self.titleLabel.textColor = .Gray8
         self.subTitleLabel.text = nil

--- a/TellingMe/tellingMe/presentation/home/viewController/HomeViewController.swift
+++ b/TellingMe/tellingMe/presentation/home/viewController/HomeViewController.swift
@@ -144,7 +144,7 @@ extension HomeViewController: HeaderViewDelegate, AlarmReadAllTappedProtocol {
     func pushAlarmNotice(_ headerView: MainHeaderView) {
         let vc = AlarmViewController()
         let navigationNewController = UINavigationController(rootViewController: vc)
-        navigationNewController.modalPresentationStyle = .overFullScreen
+        navigationNewController.modalPresentationStyle = .fullScreen
         self.present(navigationNewController, animated: true)
     }
     

--- a/TellingMe/tellingMe/presentation/home/viewController/HomeViewController.swift
+++ b/TellingMe/tellingMe/presentation/home/viewController/HomeViewController.swift
@@ -136,7 +136,11 @@ class HomeViewController: UIViewController {
     }
 }
 
-extension HomeViewController: HeaderViewDelegate {
+extension HomeViewController: HeaderViewDelegate, AlarmReadAllTappedProtocol {
+    func readAllTapped() {
+        self.headerView.alarmNoticeButton.setImage(UIImage(named: "NoticeAlarm"), for: .normal)
+    }
+    
     func pushAlarmNotice(_ headerView: MainHeaderView) {
         let vc = AlarmViewController()
         let navigationNewController = UINavigationController(rootViewController: vc)
@@ -163,6 +167,7 @@ extension HomeViewController: HeaderViewDelegate {
                 print("❎ New Notices doesn't exist.")
             }
         }
+        
     }
     
     func bindViewModel() {

--- a/TellingMe/tellingMe/presentation/home/viewController/HomeViewController.swift
+++ b/TellingMe/tellingMe/presentation/home/viewController/HomeViewController.swift
@@ -32,6 +32,7 @@ class HomeViewController: UIViewController {
         setView()
         checkNofitication()
         bindViewModel()
+        setNotificationCenterForBecomeActive()
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -62,6 +63,10 @@ class HomeViewController: UIViewController {
         for animationView in animationViews {
             animationView.layer.removeAllAnimations()
         }
+    }
+    
+    deinit {
+        NotificationCenter.default.removeObserver(self)
     }
 
     func setView() {
@@ -136,10 +141,7 @@ class HomeViewController: UIViewController {
     }
 }
 
-extension HomeViewController: HeaderViewDelegate, AlarmReadAllTappedProtocol {
-    func readAllTapped() {
-        self.headerView.alarmNoticeButton.setImage(UIImage(named: "NoticeAlarm"), for: .normal)
-    }
+extension HomeViewController: HeaderViewDelegate {
     
     func pushAlarmNotice(_ headerView: MainHeaderView) {
         let vc = AlarmViewController()
@@ -177,5 +179,32 @@ extension HomeViewController: HeaderViewDelegate, AlarmReadAllTappedProtocol {
                 self?.showPushNotification()
             })
             .disposed(by: disposeBag)
+    }
+}
+
+extension HomeViewController {
+    private func setNotificationCenterForBecomeActive() {
+        print("NotificationCenter Added for background check.")
+        NotificationCenter.default.addObserver(self, selector: #selector(refreshNetwork), name: Notification.Name("RefreshHomeView"), object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(refreshAnimation), name: Notification.Name("RefreshAnimation"), object: nil)
+    }
+    
+    private func restartAnimation() {
+        animation()
+    }
+}
+
+extension HomeViewController {
+    @objc
+    private func refreshNetwork() {
+        print("Back From Background, refreshed the question.")
+        getQuestion()
+    }
+    
+    @objc
+    private func refreshAnimation() {
+        print("Back From Background, refreshed the animation.")
+        /// This doesn't work.
+        restartAnimation()
     }
 }

--- a/TellingMe/tellingMe/presentation/tab/MainTabBarController.swift
+++ b/TellingMe/tellingMe/presentation/tab/MainTabBarController.swift
@@ -15,10 +15,7 @@ class MainTabBarController: UITabBarController {
         super.viewDidLoad()
         
         self.delegate = self
-        tabBar.layer.cornerRadius = 32
-        tabBar.layer.maskedCorners = [.layerMinXMinYCorner, .layerMaxXMinYCorner]
-        // Storyboard 에서만 세팅되어 있는 걸 여기서 한번 더 ensure 하기 위해 선언
-        tabBar.backgroundColor = .Side100
+        setTabBarAppearance()
     }
 
     func showPushNotification() {
@@ -26,6 +23,16 @@ class MainTabBarController: UITabBarController {
         guard let vc = storyboard.instantiateViewController(identifier: "pushNotificationModal") as? PushNotificationModalViewController else { return }
         vc.modalPresentationStyle = .overFullScreen
         self.present(vc, animated: true)
+    }
+    
+    private func setTabBarAppearance() {
+        let appearance = UITabBarAppearance()
+        appearance.configureWithOpaqueBackground()
+        appearance.backgroundColor = .Side100
+        tabBar.standardAppearance = appearance
+//        tabBar.scrollEdgeAppearance = tabBar.standardAppearance
+        tabBar.layer.cornerRadius = 32
+        tabBar.layer.maskedCorners = [.layerMinXMinYCorner, .layerMaxXMinYCorner]
     }
 }
 

--- a/TellingMe/tellingMe/presentation/tab/MainTabBarController.swift
+++ b/TellingMe/tellingMe/presentation/tab/MainTabBarController.swift
@@ -27,10 +27,13 @@ class MainTabBarController: UITabBarController {
     
     private func setTabBarAppearance() {
         let appearance = UITabBarAppearance()
+        tabBar.layer.masksToBounds = true
         appearance.configureWithOpaqueBackground()
         appearance.backgroundColor = .Side100
+        appearance.shadowImage = nil
         tabBar.standardAppearance = appearance
-//        tabBar.scrollEdgeAppearance = tabBar.standardAppearance
+        tabBar.scrollEdgeAppearance = tabBar.standardAppearance
+        
         tabBar.layer.cornerRadius = 32
         tabBar.layer.maskedCorners = [.layerMinXMinYCorner, .layerMaxXMinYCorner]
     }


### PR DESCRIPTION
### 📃 전달 사항
1. 분명, 알림창에서 dismiss 를 하면서 새롭게 통신을 받아와야 하는데 그러지 않아, 전체읽음을 누르면 delegate 으로 수동으로 바뀌게 만들었습니다.
2. 탭 색상이 바뀌는 걸 고쳤는데, 커스텀 탭바라서 그러지 selected Icon 일 때, 잘립니다. 이건 현재 서기+디자인팀과 얘기중입니다.
3. 바뀐 알림창 DB 구조를 채택합니다.
4. 백그라운드에서 돌아왔을 때 업데이트 됩니다. (애니메이션은 지금 안됩니다.)

### 🔴 ETC
기타 사항을 적어주세요.
실제 개발 기간 : 7 시간


### 💻 개발환경
macOS: 13.5.1
iOS: iphone 14 pro simulator

<hr>

closes: #126 
