### PR TITLE
질문 피드백 에러를 수정합니다.

### DIFF
--- a/TellingMe/tellingMe/data/base/MoyaProvider+.swift
+++ b/TellingMe/tellingMe/data/base/MoyaProvider+.swift
@@ -10,6 +10,7 @@ import Moya
 import RxSwift
 
 extension MoyaProvider {
+    /// Not Observable, only Moya and completion
     func request<Data: Codable>(
         _ target: Target,
         dtoType: Data.Type,
@@ -39,6 +40,7 @@ extension MoyaProvider {
         }
     }
 
+    /// Not Observable, only Moya and completion
     func request(
         _ target: Target,
         dtoType: Data.Type,
@@ -68,6 +70,7 @@ extension MoyaProvider {
         }
     }
     
+    /// Empty(Void) Response일 때 사용하세요.
     func request(target: Target) -> Observable<Void> {
         return Observable.create { observer in
             let request = self.request(target) { result in
@@ -95,6 +98,7 @@ extension MoyaProvider {
         }
     }
 
+    /// Empty(Void) Response가 아니고 응답값이 있을 때 사용하세요.
     func request<T: Decodable>(target: Target) -> Observable<T> {
         return Observable.create { observer in
             let request = self.request(target) { result in

--- a/TellingMe/tellingMe/data/feedback/api/QuestionFeedbackAPI.swift
+++ b/TellingMe/tellingMe/data/feedback/api/QuestionFeedbackAPI.swift
@@ -55,7 +55,7 @@ extension QuestionFeedbackAPITarget: TargetType {
 struct QuestionFeedbackAPI: Networkable {
     typealias Target = QuestionFeedbackAPITarget
 
-    static func postQuestionFeedback(request: QuestionFeedbackRequest) -> Observable<EmptyResponse> {
+    static func postQuestionFeedback(request: QuestionFeedbackRequest) -> Observable<Void> {
         do {
             let provider = try makeAuthorizedProvider()
             return provider.request(target: .postQuestionFeedback(request))

--- a/TellingMe/tellingMe/presentation/feedback/viewControllers/BadFeedbackViewController.swift
+++ b/TellingMe/tellingMe/presentation/feedback/viewControllers/BadFeedbackViewController.swift
@@ -80,6 +80,7 @@ extension BadFeedbackViewController {
             .disposed(by: disposeBag)
         
         submitButton.rx.tap
+            .throttle(.seconds(3), latest: false, scheduler: MainScheduler.instance)
             .bind(onNext: { [weak self] _ in
                 guard let self = self else { return }
                 self.viewModel.postFeedback()

--- a/TellingMe/tellingMe/presentation/feedback/viewControllers/GoodFeedbackViewController.swift
+++ b/TellingMe/tellingMe/presentation/feedback/viewControllers/GoodFeedbackViewController.swift
@@ -70,6 +70,7 @@ extension GoodFeedbackViewController {
             .disposed(by: disposeBag)
 
         submitButton.rx.tap
+            .throttle(.seconds(3), latest: false, scheduler: MainScheduler.instance)
             .bind(onNext: { [weak self] _ in
                 guard let self = self else { return }
                 self.viewModel.postFeedback()

--- a/TellingMe/tellingMe/presentation/feedback/viewModel/BadFeedbackViewModel.swift
+++ b/TellingMe/tellingMe/presentation/feedback/viewModel/BadFeedbackViewModel.swift
@@ -21,7 +21,7 @@ protocol BadFeedbackViewModelOutputs {
     var reasonText: String? { get }
     
     var alertSubject: PublishSubject<String> { get }
-    var successSubject: PublishSubject<EmptyResponse> { get }
+    var successSubject: PublishSubject<Void> { get }
     var showToastSubject: PublishSubject<String> { get }
 }
 
@@ -52,7 +52,7 @@ final class BadFeedbackViewModel: BadFeedbackViewModelInputs, BadFeedbackViewMod
     var selectedFeedback = BehaviorRelay<[Int]>(value: [])
     var reasonText: String? = nil
     var alertSubject = PublishSubject<String>()
-    var successSubject = PublishSubject<EmptyResponse>()
+    var successSubject = PublishSubject<Void>()
     var showToastSubject = PublishSubject<String>()
     
     init() {

--- a/TellingMe/tellingMe/presentation/feedback/viewModel/GoodFeedbackViewModel.swift
+++ b/TellingMe/tellingMe/presentation/feedback/viewModel/GoodFeedbackViewModel.swift
@@ -18,7 +18,7 @@ protocol GoodFeedbackViewModelInputs {
 protocol GoodFeedbackViewModelOutputs {
     var sliderValues: [Int] { get set }
     var reasonText: String? { get }
-    var successSubject: PublishSubject<EmptyResponse> { get }
+    var successSubject: PublishSubject<Void> { get }
     var showToastSubject: PublishSubject<String> { get }
 }
 
@@ -44,7 +44,7 @@ final class GoodFeedbackViewModel: GoodFeedbackViewModelType, GoodFeedbackViewMo
     var outputs: GoodFeedbackViewModelOutputs { return self }
     var sliderValues: [Int] = [3, 3, 3]
     var reasonText: String? = nil
-    let successSubject = PublishSubject<EmptyResponse>()
+    let successSubject = PublishSubject<Void>()
     let showToastSubject = PublishSubject<String>()
     
     init() {

--- a/TellingMe/tellingMe/presentation/feedback/views/FeedbackView.swift
+++ b/TellingMe/tellingMe/presentation/feedback/views/FeedbackView.swift
@@ -72,14 +72,14 @@ extension FeedbackView {
         }
         
         badLabel.snp.makeConstraints {
-            $0.top.equalTo(agreeLabel.snp.top)
-            $0.trailing.equalToSuperview()
+            $0.top.equalTo(stepView.snp.bottom).offset(4)
+            $0.leading.bottom.equalToSuperview()
             $0.height.equalTo(28)
         }
         
         agreeLabel.snp.makeConstraints {
-            $0.top.equalTo(stepView.snp.bottom).offset(4)
-            $0.leading.bottom.equalToSuperview()
+            $0.top.equalTo(badLabel.snp.top)
+            $0.trailing.equalToSuperview()
             $0.height.equalTo(28)
         }
     }

--- a/TellingMe/tellingMe/presentation/signUp/viewControllers/SignUpViewController.swift
+++ b/TellingMe/tellingMe/presentation/signUp/viewControllers/SignUpViewController.swift
@@ -41,7 +41,7 @@ final class SignUpViewController: BaseViewController {
 extension SignUpViewController {
     private func bindViewModel() {
         skipButton.rx.tap
-            .throttle(.milliseconds(1000), latest: false, scheduler: MainScheduler.instance)
+            .throttle(.milliseconds(3000), latest: false, scheduler: MainScheduler.instance)
             .bind(onNext: { [weak self] _ in
                 guard let self else { return }
                 self.scrollToNextViewController()
@@ -49,7 +49,7 @@ extension SignUpViewController {
             .disposed(by: disposeBag)
         
         leftButton.rx.tap
-            .throttle(.milliseconds(1000), latest: false, scheduler: MainScheduler.instance)
+            .throttle(.milliseconds(3000), latest: false, scheduler: MainScheduler.instance)
             .bind(onNext: { [weak self] _ in
                 guard let self else { return }
                 self.scrollToPrevViewController()
@@ -57,7 +57,7 @@ extension SignUpViewController {
             .disposed(by: disposeBag)
         
         rightButton.rx.tap
-            .throttle(.milliseconds(1000), latest: false, scheduler: MainScheduler.instance)
+            .throttle(.milliseconds(3000), latest: false, scheduler: MainScheduler.instance)
             .bind(onNext: { [weak self] _ in
                 guard let self else { return }
                 switch viewModel.currentIndex {

--- a/TellingMe/tellingMe/presentation/tab/MainTabBarController.swift
+++ b/TellingMe/tellingMe/presentation/tab/MainTabBarController.swift
@@ -24,6 +24,7 @@ class MainTabBarController: UITabBarController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         self.navigationController?.isNavigationBarHidden = true
+//        showFeedback()
         checkFeedbackDate()
     }
     

--- a/TellingMe/tellingMe/presentation/tab/MainTabBarController.swift
+++ b/TellingMe/tellingMe/presentation/tab/MainTabBarController.swift
@@ -24,7 +24,6 @@ class MainTabBarController: UITabBarController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         self.navigationController?.isNavigationBarHidden = true
-//        showFeedback()
         checkFeedbackDate()
     }
     


### PR DESCRIPTION
### 📃 전달 사항
질문 피드백 시 생기는 문제사항을 해결합니다.
기존 Request가 Empty(Void) 케이스를 거르지 못하여 OnNext가 일어나지 않아서 생긴 문제였습니다.

### 📸 스크린샷
<img src="https://github.com/telling-me/tellingme-iOS/assets/62610032/5ef34212-7002-4745-8d3d-c168b92c6dcb" width = "200"/>

### ✔ 진행사항
- [x] 그렇다/그렇지 않다 위치 바꾸기
- [x] 제출하기 중복 막기
- [x] 제출하기 이후 화면 전환 이벤트 적용하기


### 🔴 ETC
기타 사항을 적어주세요.
실제 개발 기간 : 1시간


### 💻 개발환경
macOS: Sonoma 14.0
xcode: 15.0
iOS: iphone 15 pro simulator


<hr>

closes: #163 
